### PR TITLE
fix: manifest version to allow generis update

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'version' => '1.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'generis' => '>=14.1.0',
+        'generis' => '>=13.14.0',
         'tao' => '>=46.9.2',
         'taoDelivery' => '>=14.10.1',
         'taoOutcomeUi' => '>=9.4.3',


### PR DESCRIPTION
It was not possible to run tao update:

```
  parccTei already up to date
  taoLti already up to date
  Installed version of generis 13.14.0 does not satisfy required >=14.1.0 for taoAdvancedSearch

```

fix: manifest version to allow generis update