### PR TITLE
Fix return type - cast to int

### DIFF
--- a/model/DeliveryResult/Factory/DeliveryResultFilterFactory.php
+++ b/model/DeliveryResult/Factory/DeliveryResultFilterFactory.php
@@ -44,7 +44,7 @@ class DeliveryResultFilterFactory extends ResultFilterFactory implements ResultF
             $deliveryIds[] = $result->getUri();
         }
 
-        return $this->getResultsService()
+        return (int)$this->getResultsService()
             ->getImplementation()
             ->countResultByDelivery($deliveryIds);
     }


### PR DESCRIPTION
Fix return type - cast to int. Sometimes the implementation returns string "0".

Error log:

```
2021-02-22 13:29:33 [ERROR] [tao] 'Executing task http://udir-auth.taocloud.org/tao.rdf#i6033b1bd7b4c69264b38886867e2b9e failed with MSG: Return value of oat\taoAdvancedSearch\model\DeliveryResult\Factory\DeliveryResultFilterFactory::getMax() must be of the type integer, string returned' /var/www/html/tao/models/classes/taskQueue/Worker/AbstractWorker.php 104

```

https://oat-sa.atlassian.net/browse/ADF-33