### PR TITLE
add lib-tao-elasticseaarch to required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "oat-sa/generis": ">=14.2.0",
     "oat-sa/tao-core": ">=48.0.0",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
-    "oat-sa/extension-tao-outcomeui": ">=10.4.0"
+    "oat-sa/extension-tao-outcomeui": ">=10.4.0",
+    "oat-sa/lib-tao-elasticsearch": "1.2.0"
 },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
If we will not have this dependency here we will need to separately require lib-tao-elasticsearch