### PR TITLE
fix: add command to fix resource indexation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,22 @@ Index vs Storage
     Percentage indexed: 8.7%
     Missing items: 21
 ```
+
+### Reindex missing resources
+
+```shell
+php index.php 'oat\taoAdvancedSearch\scripts\tools\IndexMissingRecords' -h
+```
+
+Output example:
+
+```shell
+Resources not indexed for class http://www.tao.lu/Ontologies/TAOItem.rdf#Item
+  Missing resources
+    https://advanced-search-tao.docker.localhost/ontologies/tao.rdf#i60f6d9d5037dc2624b07bbfa0fedd8963 (A_Class_Item_1 bis)
+  ReIndexed resources
+    https://advanced-search-tao.docker.localhost/ontologies/tao.rdf#i60f6d9d5037dc2624b07bbfa0fedd8963 (A_Class_Item_1 bis)
+  Summary
+    Missing resources: 1
+    Missing resources indexed: 1
+```

--- a/model/Resource/Service/SyncResourceResultIndexer.php
+++ b/model/Resource/Service/SyncResourceResultIndexer.php
@@ -22,15 +22,12 @@ declare(strict_types=1);
 
 namespace oat\taoAdvancedSearch\model\Resource\Service;
 
-use core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\search\index\IndexService;
 use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
-use oat\taoAdvancedSearch\model\Index\Normalizer\NormalizerInterface;
 use oat\taoAdvancedSearch\model\Index\Service\IndexerInterface;
-use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use Throwable;
 
 class SyncResourceResultIndexer extends ConfigurableService implements IndexerInterface
@@ -45,11 +42,21 @@ class SyncResourceResultIndexer extends ConfigurableService implements IndexerIn
 
             $document = $documentBuilder->createDocumentFromResource($resource);
 
-            $this->getSearch()->index(
+            $totalIndexed = $this->getSearch()->index(
                 [
                     $document,
                 ]
             );
+
+            if ($totalIndexed < 1) {
+                $this->logWarning(
+                    sprintf(
+                        'Could not index resource %s (%s)',
+                        $resource->getLabel(),
+                        $resource->getUri()
+                    )
+                );
+            }
         } catch (Throwable $exception) {
             $this->logError(
                 sprintf(

--- a/scripts/tools/IndexMissingRecords.php
+++ b/scripts/tools/IndexMissingRecords.php
@@ -37,6 +37,9 @@ use oat\taoAdvancedSearch\model\Resource\Service\SyncResourceResultIndexer;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
+/**
+ * php index.php 'oat\taoAdvancedSearch\scripts\tools\IndexMissingRecords' -h
+ */
 class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;

--- a/scripts/tools/IndexMissingRecords.php
+++ b/scripts/tools/IndexMissingRecords.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\scripts\tools;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+use oat\search\base\ResultSetInterface;
+use oat\tao\elasticsearch\ElasticSearch;
+use oat\tao\elasticsearch\IndexerInterface;
+use oat\tao\elasticsearch\Query;
+use oat\tao\model\search\SearchProxy;
+use oat\tao\model\TaoOntology;
+use oat\taoAdvancedSearch\model\Resource\Service\SyncResourceResultIndexer;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+    use OntologyAwareTrait;
+
+    protected function provideUsage(): array
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Type this option to see the parameters.'
+        ];
+    }
+
+    protected function provideOptions(): array
+    {
+        return [
+            'class' => [
+                'prefix' => 'c',
+                'longPrefix' => 'class',
+                'flag' => false,
+                'description' => 'Resource class URI',
+                'defaultValue' => TaoOntology::CLASS_URI_ITEM
+            ],
+            'reindex' => [
+                'prefix' => 'r',
+                'longPrefix' => 'reindex',
+                'flag' => false,
+                'description' => 'Force reindex missing resources',
+                'defaultValue' => false
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return 'Show indexation summary';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function run(): Report
+    {
+        $class = $this->getOption('class');
+        $reindex = boolval($this->getOption('reindex'));
+        $mainReport = Report::createInfo(sprintf('Resources not indexed for class %s', $class));
+        $missingIndexReport = Report::createWarning('Missing resources');
+        $mainReport->add($missingIndexReport);
+        $missingResources = [];
+        $missingResourcesIndexed = [];
+
+        /** @var core_kernel_classes_Resource $resource */
+        foreach ($this->search($class) as $resource) {
+            if (!$resource->exists()) {
+                continue;
+            }
+
+            if (!$this->isIndexed($this->getIndexName($class), $resource->getUri())) {
+                $missingResources[$resource->getUri()] = $resource;
+
+                $missingIndexReport->add(
+                    Report::createInfo(
+                        $resource->getUri() . ' (' . $resource->getLabel() . ')'
+                    )
+                );
+            }
+        }
+
+        if ($reindex) {
+            $reIndexedReport = Report::createSuccess('ReIndexed resources');
+            $mainReport->add($reIndexedReport);
+
+            foreach ($missingResources as $resource) {
+                /** @var SyncResourceResultIndexer $indexer */
+                $indexer = $this->getServiceManager()->get(SyncResourceResultIndexer::class);
+
+                $reIndexedReport->add(
+                    Report::createInfo(
+                        $resource->getUri() . ' (' . $resource->getLabel() . ')'
+                    )
+                );
+
+                $indexer->addIndex($resource);
+
+                $missingResourcesIndexed[$resource->getUri()] = $resource->getLabel();
+            }
+        }
+
+        $summaryReport = Report::createSuccess('Summary');
+        $summaryReport->add(Report::createInfo('Missing resources: ' . count($missingResources)));
+        $summaryReport->add(Report::createInfo('Missing resources indexed: ' . count($missingResourcesIndexed)));
+
+        $mainReport->add($summaryReport);
+
+        return $mainReport;
+    }
+
+    private function isIndexed(string $index, string $uri)
+    {
+        $advancedSearch = $this->getElasticSearch();
+
+        $query = new Query($index);
+        $query->addCondition('_id:"' . $uri . '"');
+        $query->setLimit(1);
+
+        return $advancedSearch->search($query)->getTotalCount() > 0;
+    }
+
+    private function getIndexName(string $classUri): ?string
+    {
+        //@TODO Remove direct call for ElasticSearch
+        return IndexerInterface::AVAILABLE_INDEXES[$classUri] ?? null;
+    }
+
+    private function search(string $classUri): ResultSetInterface
+    {
+        $search = $this->getComplexSearchService();
+
+        $queryBuilder = $search->query();
+
+        $criteria = $search->searchType($queryBuilder, $classUri, true);
+
+        $queryBuilder = $queryBuilder->setCriteria($criteria);
+
+        return $search->getGateway()->search($queryBuilder);
+    }
+
+    private function getElasticSearch(): ElasticSearch
+    {
+        return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID)->getAdvancedSearch();
+    }
+
+    private function getComplexSearchService(): ComplexSearchService
+    {
+        return $this->getServiceLocator()->get(ComplexSearchService::SERVICE_ID);
+    }
+}

--- a/scripts/tools/IndexMissingRecords.php
+++ b/scripts/tools/IndexMissingRecords.php
@@ -73,6 +73,7 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
             ],
             'offset' => [
                 'prefix' => 'o',
+                'cast' => 'int',
                 'longPrefix' => 'offset',
                 'flag' => false,
                 'description' => 'offset of search results',
@@ -80,6 +81,7 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
             ],
             'limit' => [
                 'prefix' => 'l',
+                'cast' => 'int',
                 'longPrefix' => 'limit',
                 'flag' => false,
                 'description' => 'limit of search results',
@@ -99,8 +101,8 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
     protected function run(): Report
     {
         $class = $this->getOption('class');
-        $offset = (int)$this->getOption('offset');
-        $limit = (int)$this->getOption('limit');
+        $offset = $this->getOption('offset');
+        $limit = $this->getOption('limit');
         $reindex = boolval($this->getOption('reindex'));
         $missingResources = 0;
         $missingResourcesIndexed = 0;
@@ -154,7 +156,7 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
     private function isIndexed(ElasticSearch $search, string $index, string $uri): bool
     {
         $query = new Query($index);
-        $query->addCondition('_id:"' . $uri . '"');
+        $query->addCondition(sprintf('_id:"%s"', $uri));
         $query->setLimit(1);
 
         return $search->search($query)->getTotalCount() > 0;

--- a/scripts/tools/IndexMissingRecords.php
+++ b/scripts/tools/IndexMissingRecords.php
@@ -83,7 +83,7 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
                 'longPrefix' => 'limit',
                 'flag' => false,
                 'description' => 'limit of search results',
-                'defaultValue' => 50
+                'defaultValue' => 0
             ]
         ];
     }
@@ -179,8 +179,11 @@ class IndexMissingRecords extends ScriptAction implements ServiceLocatorAwareInt
 
         $queryBuilder = $queryBuilder->setCriteria($criteria);
 
-        $queryBuilder->setLimit($limit);
         $queryBuilder->setOffset($offset);
+
+        if ($limit > 0) {
+            $queryBuilder->setLimit($limit);
+        }
 
         return $search->getGateway()->search($queryBuilder);
     }


### PR DESCRIPTION
fix: add command to fix resource indexation

How to test locally:

```
php index.php 'oat\taoAdvancedSearch\scripts\tools\IndexMissingRecords' -h
```

https://oat-sa.atlassian.net/browse/ADF-730