### PR TITLE
fix: Don't use current() with ResultSet instances

### DIFF
--- a/model/Metadata/Service/ClassMetadataSearcher.php
+++ b/model/Metadata/Service/ClassMetadataSearcher.php
@@ -116,13 +116,22 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
 
     private function getMainClassProperties(string $classUri): array
     {
-        $result = $this->executeQuery('_id', $classUri);
+        $resultSet = $this->executeQuery('_id', $classUri);
 
-        if ($result->getTotalCount() === 0) {
-            return [];
+        // ResultSets extend from ArrayIterator, and we should not call current()
+        // on that ("Calling current() on an object is deprecated" errors).
+        //
+        // Moreover, hits.total (used to provide the value for getTotalCount()) may
+        // not be accurate at all on Elasticsearch 7.0+.
+        //
+        // To be extra safe, we iterate the result set but just return
+        // the first result immediately
+        //
+        foreach ($resultSet as $result) {
+            return $result; // Return always the first one
         }
 
-        return current($result);
+        return [];
     }
 
     private function filterDuplicatedProperties(array $allProperties): array

--- a/model/Metadata/Service/ClassMetadataSearcher.php
+++ b/model/Metadata/Service/ClassMetadataSearcher.php
@@ -116,22 +116,9 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
 
     private function getMainClassProperties(string $classUri): array
     {
-        $resultSet = $this->executeQuery('_id', $classUri);
+        $results = (array) $this->executeQuery('_id', $classUri);
 
-        // ResultSets extend from ArrayIterator, and we should not call current()
-        // on that ("Calling current() on an object is deprecated" errors).
-        //
-        // Moreover, hits.total (used to provide the value for getTotalCount()) may
-        // not be accurate at all on Elasticsearch 7.0+.
-        //
-        // To be extra safe, we iterate the result set but just return
-        // the first result immediately
-        //
-        foreach ($resultSet as $result) {
-            return $result; // Return always the first one
-        }
-
-        return [];
+        return !empty($results) ? current($results) : [];
     }
 
     private function filterDuplicatedProperties(array $allProperties): array

--- a/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
+++ b/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
@@ -163,6 +163,45 @@ class ClassMetadataSearcherTest extends TestCase
         $this->assertSame('class1', $rawResult[0]['class']);
     }
 
+    public function testFindAllUsingElasticSearchWithEmptyClassProperties(): void
+    {
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property->method('getRelatedClass')
+            ->willReturn(null);
+
+        $class = $this->createMock(core_kernel_classes_Property::class);
+        $class->method('getLabel')
+            ->willReturn('Class label');
+
+        $this->ontology
+            ->method('getProperty')
+            ->willReturn($property);
+
+        $this->ontology
+            ->method('getClass')
+            ->willReturn($class);
+
+        $this->advancedSearchChecker
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->elasticSearch
+            ->method('search')
+            ->willReturn(new SearchResult([], 0));
+
+        $result = $this->subject->findAll(
+            new ClassMetadataSearchInput(
+                (new ClassMetadataSearchRequest())->setClassUri('class1')
+            )
+        );
+
+        $rawResult = json_decode(json_encode($result->jsonSerialize()), true);
+
+        $this->assertSame(null, $rawResult[0]['parent-class']);
+        $this->assertSame('class1', $rawResult[0]['class']);
+        $this->assertSame([], $rawResult[0]['metadata']);
+    }
+
     private function getMockResult(string $classId, ?string $parentClassUri, array $classPath): array
     {
         return [
@@ -174,12 +213,14 @@ class ClassMetadataSearcherTest extends TestCase
                     'propertyUri' => 'propertyUri1',
                     'propertyLabel' => 'propertyLabel1',
                     'propertyType' => 'list',
+                    'propertyAlias' => null,
                     'propertyValues' => [],
                 ],
                 [
                     'propertyUri' => 'propertyUri2',
                     'propertyLabel' => 'propertyLabel2',
                     'propertyType' => 'text',
+                    'propertyAlias' => null,
                     'propertyValues' => [],
                 ]
             ],

--- a/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
+++ b/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
@@ -31,11 +31,13 @@ use oat\tao\elasticsearch\SearchResult;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
 use oat\tao\model\Lists\Business\Domain\ClassMetadataSearchRequest;
+use oat\tao\model\Lists\Business\Domain\MetadataCollection;
 use oat\tao\model\Lists\Business\Input\ClassMetadataSearchInput;
 use oat\tao\model\Lists\Business\Service\ClassMetadataService;
 use oat\tao\model\search\SearchProxy;
 use oat\taoAdvancedSearch\model\Metadata\Service\ClassMetadataSearcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Traversable;
 
 class ClassMetadataSearcherTest extends TestCase
 {
@@ -195,11 +197,18 @@ class ClassMetadataSearcherTest extends TestCase
             )
         );
 
-        $rawResult = json_decode(json_encode($result->jsonSerialize()), true);
+        $generator = $result->getIterator();
+        $this->assertInstanceOf(Traversable::class, $generator);
 
-        $this->assertSame(null, $rawResult[0]['parent-class']);
-        $this->assertSame('class1', $rawResult[0]['class']);
-        $this->assertSame([], $rawResult[0]['metadata']);
+        $items = iterator_to_array($generator);
+        $this->assertCount(1, $items);
+        $this->assertNull($items[0]->getParentClass());
+        $this->assertEquals('class1', $items[0]->getClass());
+
+        $metadata = $items[0]->getMetaData();
+        $this->assertInstanceOf(MetadataCollection::class, $metadata);
+        $this->assertEquals(0, $metadata->count());
+        $this->assertEmpty(iterator_to_array($metadata));
     }
 
     private function getMockResult(string $classId, ?string $parentClassUri, array $classPath): array

--- a/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
+++ b/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
@@ -27,6 +27,7 @@ use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\log\LoggerService;
 use oat\tao\elasticsearch\ElasticSearch;
+use oat\tao\elasticsearch\Query;
 use oat\tao\elasticsearch\SearchResult;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
@@ -189,6 +190,9 @@ class ClassMetadataSearcherTest extends TestCase
 
         $this->elasticSearch
             ->method('search')
+            ->with($this->callback(function (Query $query) {
+                return ($query->getQueryString() == '_id:"class1"');
+            }))
             ->willReturn(new SearchResult([], 0));
 
         $result = $this->subject->findAll(

--- a/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
+++ b/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
@@ -191,7 +191,8 @@ class ClassMetadataSearcherTest extends TestCase
         $this->elasticSearch
             ->method('search')
             ->with($this->callback(function (Query $query) {
-                return ($query->getQueryString() == '_id:"class1"');
+                return (($query->getQueryString() == '_id:"class1"')
+                    && ($query->getIndex() == 'property-list'));
             }))
             ->willReturn(new SearchResult([], 0));
 


### PR DESCRIPTION
**Associated Jira issue:** [ADF-912](https://oat-sa.atlassian.net/browse/ADF-912)

`ResultSet`s extend from `ArrayIterator`, and we should not call `current()` on that (to prevent "Calling current() on an object is deprecated" errors).

Moreover, `hits.total` (used to provide the value for `getTotalCount()`) may not be accurate at all on Elasticsearch 7.0+ (see [ES 7.0 breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response)).

To be extra safe, we cast the result set to an array and try to return the first one (with `current()`) **only** if the array is not empty; otherwise we explicitly return an empty array.