### PR TITLE
chore: update elasticsearch lib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/tao-core": ">=v48.52.0",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
     "oat-sa/extension-tao-outcomeui": ">=10.4.0",
-    "oat-sa/lib-tao-elasticsearch": ">=2.3.0"
+    "oat-sa/lib-tao-elasticsearch": "dev-fix/ADF-913/add-acl-support-query-builder as 2.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/tao-core": ">=v48.52.0",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
     "oat-sa/extension-tao-outcomeui": ">=10.4.0",
-    "oat-sa/lib-tao-elasticsearch": "dev-fix/ADF-913/add-acl-support-query-builder as 2.3.0"
+    "oat-sa/lib-tao-elasticsearch": ">=2.3.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-913

The goal here is to make the ACL validation for search query only required if the user has no Admin or DacSimple administrator rights.

The idea is to simulate a 'fake' permission check that will only work in case the user is a TaoDacSimple administrator.