### PR TITLE
fix: validate prefix and display error to user

### DIFF
--- a/model/SearchEngine/Service/IndexPrefixer.php
+++ b/model/SearchEngine/Service/IndexPrefixer.php
@@ -24,10 +24,13 @@ declare(strict_types=1);
 
 namespace oat\taoAdvancedSearch\model\SearchEngine\Service;
 
+use InvalidArgumentException;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchConfig;
 
 class IndexPrefixer
 {
+    private const VALID_PREFIX_REGEX = '/[^a-z0-9\-]/';
+
     /** @var ElasticSearchConfig */
     private $config;
 
@@ -36,10 +39,23 @@ class IndexPrefixer
         $this->config = $config;
     }
 
+    public function validate(string $prefix): void
+    {
+        if (preg_replace(self::VALID_PREFIX_REGEX, '', $prefix) !== $prefix) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The index prefix %s does not follow the patter %s',
+                    $prefix,
+                    self::VALID_PREFIX_REGEX
+                )
+            );
+        }
+    }
+
     public function prefix(string $indexName): string
     {
         if ($this->config->getIndexPrefix()) {
-            return preg_replace('/[^a-z\-]/', '', $this->config->getIndexPrefix()) . '-' . $indexName;
+            return $this->config->getIndexPrefix() . '-' . $indexName;
         }
 
         return $indexName;

--- a/model/SearchEngine/Service/IndexPrefixer.php
+++ b/model/SearchEngine/Service/IndexPrefixer.php
@@ -44,7 +44,7 @@ class IndexPrefixer
         if (preg_replace(self::VALID_PREFIX_REGEX, '', $prefix) !== $prefix) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'The index prefix %s does not follow the patter %s',
+                    'The index prefix %s does not follow the pattern %s',
                     $prefix,
                     self::VALID_PREFIX_REGEX
                 )

--- a/tests/Unit/SearchEngine/Service/IndexPrefixerTest.php
+++ b/tests/Unit/SearchEngine/Service/IndexPrefixerTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace oat\taoAdvancedSearch\tests\Unit\SearchEngine\Service;
 
+use InvalidArgumentException;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchConfig;
 use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -52,17 +53,42 @@ class IndexPrefixerTest extends TestCase
 
         $this->assertEquals(
             [
-                'p-a',
+                'p-a1',
                 'p-b',
-                'p-c'
+                'p-c2'
             ],
             $this->sut->prefixAll(
                 [
-                    'a',
+                    'a1',
                     'b',
-                    'c'
+                    'c2'
                 ]
             )
         );
+    }
+
+    /**
+     * @dataProvider validateDataProvider
+     */
+    public function testValidate(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->sut->validate($value);
+    }
+
+    public function validateDataProvider(): array
+    {
+        return [
+            'no camel Case allowed' => [
+                'Abc123',
+            ],
+            'no space allowed' => [
+                'ab c',
+            ],
+            'no special chars allowed' => [
+                'abc123$',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This will validate and not allow activate with invalid prefix:

```
root@50649d01baa8:/var/www/html# php index.php 'oat\taoAdvancedSearch\scripts\tools\Activate' --indexPrefix %%787878
Started switch to elastic search
  Unable to activate ElasticSearch: The index prefix %%787878 does not follow the patter /[^a-z0-9\-]/ - TRACE: #0 /var/www/html/taoAdvancedSearch/scripts/tools/Activate.php(170): ....
```