### PR TITLE
Add additional check for case when hits are empty

### DIFF
--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
@@ -194,8 +194,8 @@ class ElasticSearchIndexer implements IndexerInterface
         $hits = $response['hits'] ?? [];
 
         $document = [];
-        if ($hits && isset($hits['hits'], $hits['total'], $hits['total'])) {
-            $document = current($hits['hits']);
+        if ($hits && isset($hits['hits'], $hits['total'])) {
+            $document = current($hits['hits']) ?: [];
         }
 
         return $document;


### PR DESCRIPTION
Jira bug is [AUT-2681](https://oat-sa.atlassian.net/browse/AUT-2681)

It is may be reproduces using taoAdvancedSearch and taoBooklet together.
When you try to delete taoBooklet instance it raises 500 error with such kind of error message:
```
"2022-09-23 08:56:45 [ERROR] [tao] 'Unable to delete resource \"::https://lutpr02coe.eu.preprod.premium.taocloud.org/#i632c79b94eb2f1717d10cd188c12f142e\" (Return value of oat\\taoAdvancedSearch\\model\\SearchEngine\\Driver\\Elasticsearch\\ElasticSearchIndexer::searchResourceByIds() must be of the type array, bool returned).' /var/www/html/tao/generis/core/resource/Service/ResourceDeleter.php 56"
```