### PR TITLE
fix: Use the DI container in IndexUpdater to retrieve services

### DIFF
--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -159,6 +159,10 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
         $qtiItem = $this->qtiItemService->getDataItemByRdfItem($resource);
 
+        if ($qtiItem === null) {
+            return [];
+        }
+
         return $this->idDiscoverService->discover(
             array_merge(
                 $this->itemElementReferencesExtractor->extract(

--- a/model/SearchEngine/Driver/Elasticsearch/IndexUpdater.php
+++ b/model/SearchEngine/Driver/Elasticsearch/IndexUpdater.php
@@ -43,7 +43,14 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
         $queryNewProperty = [];
         $queryRemoveOldProperty = [];
         foreach ($properties as $propertyData) {
-            if (!isset($propertyData['type'], $propertyData['parentClasses'], $propertyData['oldName'], $propertyData['newName'])) {
+            if (
+                !isset(
+                    $propertyData['type'],
+                    $propertyData['parentClasses'],
+                    $propertyData['oldName'],
+                    $propertyData['newName']
+                )
+            ) {
                 continue;
             }
 
@@ -114,8 +121,12 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
     /**
      * @throws FailToUpdatePropertiesException
      */
-    public function updatePropertyValue(string $typeOrId, array $parentClasses, string $propertyName, array $value): void
-    {
+    public function updatePropertyValue(
+        string $typeOrId,
+        array $parentClasses,
+        string $propertyName,
+        array $value
+    ): void {
         $index = $this->findIndex($parentClasses, $typeOrId);
 
         if ($index === IndexerInterface::UNCLASSIFIEDS_DOCUMENTS_INDEX) {

--- a/model/SearchEngine/Driver/Elasticsearch/IndexUpdater.php
+++ b/model/SearchEngine/Driver/Elasticsearch/IndexUpdater.php
@@ -244,11 +244,11 @@ class IndexUpdater extends ConfigurableService implements IndexUpdaterInterface
 
     private function getPrefixer(): IndexPrefixer
     {
-        return $this->getServiceManager()->get(IndexPrefixer::class);
+        return $this->getServiceManager()->getContainer()->get(IndexPrefixer::class);
     }
 
     private function getClient(): Client
     {
-        return $this->getServiceManager()->get(Client::class);
+        return $this->getServiceManager()->getContainer()->get(Client::class);
     }
 }

--- a/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
+++ b/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
@@ -182,6 +182,46 @@ class AdvancedSearchIndexDocumentBuilderTest extends TestCase
         );
     }
 
+    public function testCreateDocumentFromResourceItemWithNoQtiItem(): void
+    {
+        $anItem = $this->mockResource([TaoOntology::CLASS_URI_ITEM]);
+
+        $this->document
+            ->method('getBody')
+            ->willReturn([
+                'type' => ['document type'],
+            ]);
+
+        $this->parentBuilder
+            ->expects($this->once())
+            ->method('createDocumentFromResource')
+            ->with($anItem)
+            ->willReturn($this->document);
+
+        $this->itemService
+            ->expects($this->once())
+            ->method('getDataItemByRdfItem')
+            ->willReturn(null);
+
+        $this->elementReferencesExtractor
+            ->expects($this->never())
+            ->method('extract');
+
+        $this->idDiscoverService
+            ->expects($this->never())
+            ->method('discover');
+
+        $document = $this->sut->createDocumentFromResource($anItem);
+
+        $this->assertEquals(
+            [
+                'type' => ['document type'],
+                'asset_uris' => [],
+            ],
+            $document->getBody()
+        );
+    }
+
     public function testCreateDocumentFromResourceTest(): void
     {
         $item1 = $this->mockResource([TaoOntology::CLASS_URI_ITEM]);


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1320](https://oat-sa.atlassian.net/browse/ADF-1320)

The services are registered [in this service provider](https://github.com/oat-sa/extension-tao-advanced-search/blob/fix/ADF-1320-indexupdater-use-di-container/model/SearchEngine/ServiceProvider/SearchEngineProvider.php).

Related PRs:
- https://github.com/oat-sa/tao-core/pull/3758
- https://github.com/oat-sa/extension-tao-dac-simple/pull/211

[ADF-1320]: https://oat-sa.atlassian.net/browse/ADF-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ