### PR TITLE
fix: Queue initialization

### DIFF
--- a/scripts/install/RegisterTaskQueueServices.php
+++ b/scripts/install/RegisterTaskQueueServices.php
@@ -46,7 +46,8 @@ class RegisterTaskQueueServices extends InstallAction
         $newAssociations = $this->getNewAssociations($this->getQueueName());
 
         try {
-            $this->getAssociationService()->associateBulk($newQueueName, $newAssociations);
+            $newQueue = $this->getAssociationService()->associateBulk($newQueueName, $newAssociations);
+            $this->propagate($newQueue);
         } catch (Exception $exception) {
             return new Report(Report::TYPE_ERROR, $exception->getMessage());
         }
@@ -82,7 +83,8 @@ class RegisterTaskQueueServices extends InstallAction
         return self::QUEUE_NAME;
     }
 
-    private function getAssociationService(): QueueAssociationService{
+    private function getAssociationService(): QueueAssociationService
+    {
         return $this->getServiceManager()->get(QueueAssociationService::class);
     }
 


### PR DESCRIPTION
Previously if `taoAdvanceSearch` extension is added to extension list which need to be installed the following issue occurs during tao installation:
```
Agument 1 passed to oat\tao\model\taskQueue\Queue\Broker\AbstractQueueBroker::setServiceLocator() must implement interface Laminas\ServiceManager\ServiceLocatorInterface, null given, called in /var/www/html/tao/models/classes/taskQueue/Queue.php on line 145
```
The PR should fix the issue