### PR TITLE
fix: advanced search indexation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "ext-json": "*",
     "oat-sa/generis": ">=15.22",
-    "oat-sa/tao-core": ">=50.29",
+    "oat-sa/tao-core": ">=53.7.1",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
     "oat-sa/extension-tao-outcome": ">=13.0.0",
     "oat-sa/extension-tao-test": ">=15.15.1",

--- a/model/DeliveryResult/Repository/DeliveryResultRepository.php
+++ b/model/DeliveryResult/Repository/DeliveryResultRepository.php
@@ -44,7 +44,7 @@ class DeliveryResultRepository extends ResultFilterFactory implements DeliveryRe
 
         $resultStorage = $this->getResultServerService()->getResultStorage();
 
-        return $resultStorage->countResultByDelivery($deliveryIds);
+        return (int)$resultStorage->countResultByDelivery($deliveryIds);
     }
 
     private function getResultServerService(): ResultServerService

--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -192,10 +192,6 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private function getDocumentBuilder(): IndexDocumentBuilderInterface
     {
-        //@TODO Check if we can add this in the IndexService::getDocumentBuilder method
-        $service = $this->indexService->getDocumentBuilder();
-        $service->setServiceLocator(ServiceManager::getServiceManager());
-
-        return $service;
+        return $this->indexService->getDocumentBuilder();
     }
 }

--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -28,7 +28,6 @@ use oat\oatbox\service\ServiceManager;
 use oat\tao\model\media\TaoMediaResolver;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use oat\tao\model\TaoOntology;
 use oat\taoAdvancedSearch\model\Test\Normalizer\TestNormalizer;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
@@ -48,21 +47,21 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private ElementReferencesExtractor $itemElementReferencesExtractor;
     private QtiItemService $qtiItemService;
-    private IndexService $indexService;
+    private IndexDocumentBuilderInterface $legacyDocumentBuilder;
     private IdDiscoverService $idDiscoverService;
     private ?TaoMediaResolver $itemMediaResolver;
     private TestNormalizer $testNormalizer;
 
     public function __construct(
         ElementReferencesExtractor $itemElementReferencesExtractor,
-        IndexService $indexService,
+        IndexDocumentBuilderInterface $legacyDocumentBuilder,
         IdDiscoverService $idDiscoverService,
         TestNormalizer $testNormalizer,
         QtiItemService $qtiItemService = null,
         TaoMediaResolver $itemMediaResolver = null
     ) {
         $this->itemElementReferencesExtractor = $itemElementReferencesExtractor;
-        $this->indexService = $indexService;
+        $this->legacyDocumentBuilder = $legacyDocumentBuilder;
         $this->idDiscoverService = $idDiscoverService;
         $this->testNormalizer = $testNormalizer;
         $this->qtiItemService = $qtiItemService ?? QtiItemService::singleton();
@@ -82,13 +81,13 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
         return $this->populateReferences(
             $resource,
-            $this->getDocumentBuilder()->createDocumentFromResource($resource)
+            $this->legacyDocumentBuilder->createDocumentFromResource($resource)
         );
     }
 
     public function createDocumentFromArray(array $resourceData = []): IndexDocument
     {
-        return $this->getDocumentBuilder()->createDocumentFromArray($resourceData);
+        return $this->legacyDocumentBuilder->createDocumentFromArray($resourceData);
     }
 
     /**
@@ -188,10 +187,5 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
         }
 
         return false;
-    }
-
-    private function getDocumentBuilder(): IndexDocumentBuilderInterface
-    {
-        return $this->indexService->getDocumentBuilder();
     }
 }

--- a/model/Index/Service/SyncResultIndexer.php
+++ b/model/Index/Service/SyncResultIndexer.php
@@ -24,7 +24,7 @@ namespace oat\taoAdvancedSearch\model\Index\Service;
 
 use common_Exception;
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\search\index\IndexService;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
 use oat\taoAdvancedSearch\model\Index\Normalizer\NormalizerInterface;
@@ -49,7 +49,7 @@ class SyncResultIndexer extends ConfigurableService implements IndexerInterface,
         $normalizedResource = $this->normalizer->normalize($resource);
 
         try {
-            $document = $this->getIndexerService()->getDocumentBuilder()->createDocumentFromArray(
+            $document = $this->getLegacyIndexDocumentBuilder()->createDocumentFromArray(
                 [
                     'id' => $normalizedResource->getId(),
                     'body' => $normalizedResource->getData()
@@ -82,11 +82,8 @@ class SyncResultIndexer extends ConfigurableService implements IndexerInterface,
         return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
     }
 
-    private function getIndexerService(): IndexService
+    private function getLegacyIndexDocumentBuilder(): IndexDocumentBuilderInterface
     {
-        $service = $this->getServiceLocator()->get(IndexService::SERVICE_ID);
-        $service->setServiceLocator($this->getServiceManager());
-
-        return $service;
+        return $this->getServiceLocator()->getContainer()->get(IndexDocumentBuilderInterface::class);
     }
 }

--- a/model/Index/Service/SyncResultIndexer.php
+++ b/model/Index/Service/SyncResultIndexer.php
@@ -49,7 +49,7 @@ class SyncResultIndexer extends ConfigurableService implements IndexerInterface,
         $normalizedResource = $this->normalizer->normalize($resource);
 
         try {
-            $document = $this->getLegacyIndexDocumentBuilder()->createDocumentFromArray(
+            $document = $this->getIndexDocumentBuilder()->createDocumentFromArray(
                 [
                     'id' => $normalizedResource->getId(),
                     'body' => $normalizedResource->getData()
@@ -82,8 +82,8 @@ class SyncResultIndexer extends ConfigurableService implements IndexerInterface,
         return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
     }
 
-    private function getLegacyIndexDocumentBuilder(): IndexDocumentBuilderInterface
+    private function getIndexDocumentBuilder(): IndexDocumentBuilderInterface
     {
-        return $this->getServiceLocator()->getContainer()->get(IndexDocumentBuilderInterface::class);
+        return $this->getServiceLocator()->getContainer()->get(AdvancedSearchIndexDocumentBuilder::class);
     }
 }

--- a/model/Index/ServiceProvider/IndexServiceProvider.php
+++ b/model/Index/ServiceProvider/IndexServiceProvider.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\model\Index\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-use oat\tao\model\search\index\IndexService;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\taoAdvancedSearch\model\Index\Service\AdvancedSearchIndexDocumentBuilder;
 use oat\taoAdvancedSearch\model\Test\Normalizer\TestNormalizer;
 use oat\taoMediaManager\model\relation\service\IdDiscoverService;
@@ -44,7 +44,7 @@ class IndexServiceProvider implements ContainerServiceProviderInterface
         $services->set(AdvancedSearchIndexDocumentBuilder::class, AdvancedSearchIndexDocumentBuilder::class)
             ->args([
                 service(ElementReferencesExtractor::class),
-                service(IndexService::class),
+                service(IndexDocumentBuilderInterface::class),
                 service(IdDiscoverService::class),
                 service(TestNormalizer::class),
             ])->public();

--- a/model/Test/Normalizer/TestNormalizer.php
+++ b/model/Test/Normalizer/TestNormalizer.php
@@ -110,7 +110,6 @@ class TestNormalizer
     private function getDocumentBuilder(): IndexDocumentBuilderInterface
     {
         $service = $this->indexService->getDocumentBuilder();
-        $service->setServiceLocator(ServiceManager::getServiceManager());
 
         return $service;
     }

--- a/model/Test/Normalizer/TestNormalizer.php
+++ b/model/Test/Normalizer/TestNormalizer.php
@@ -24,7 +24,6 @@ namespace oat\taoAdvancedSearch\model\Test\Normalizer;
 
 use core_kernel_classes_Resource;
 use Exception;
-use oat\oatbox\service\ServiceManager;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
 use taoQtiTest_models_classes_QtiTestService as QtiTestService;

--- a/model/Test/Normalizer/TestNormalizer.php
+++ b/model/Test/Normalizer/TestNormalizer.php
@@ -27,7 +27,6 @@ use Exception;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use taoQtiTest_models_classes_QtiTestService as QtiTestService;
 
 class TestNormalizer
@@ -46,17 +45,17 @@ class TestNormalizer
     ];
 
     private QtiTestService $qtiTestService;
-    private IndexService $indexService;
+    private IndexDocumentBuilderInterface $legacyDocumentBuilder;
 
-    public function __construct(QtiTestService $qtiTestService, IndexService $indexService)
+    public function __construct(QtiTestService $qtiTestService, IndexDocumentBuilderInterface $legacyDocumentBuilder)
     {
         $this->qtiTestService = $qtiTestService;
-        $this->indexService = $indexService;
+        $this->legacyDocumentBuilder = $legacyDocumentBuilder;
     }
 
     public function normalize(core_kernel_classes_Resource $resource): IndexDocument
     {
-        $document = $this->getDocumentBuilder()->createDocumentFromResource($resource);
+        $document = $this->legacyDocumentBuilder->createDocumentFromResource($resource);
         $jsonData = json_decode($this->qtiTestService->getJsonTest($resource), true);
 
         $body = $document->getBody();
@@ -105,12 +104,5 @@ class TestNormalizer
         }
 
         return array_values($itemURIs);
-    }
-
-    private function getDocumentBuilder(): IndexDocumentBuilderInterface
-    {
-        $service = $this->indexService->getDocumentBuilder();
-
-        return $service;
     }
 }

--- a/model/Test/ServiceProvider/TestServiceProvider.php
+++ b/model/Test/ServiceProvider/TestServiceProvider.php
@@ -43,7 +43,7 @@ class TestServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(taoQtiTest_models_classes_QtiTestService::class),
-                    service(IndexDocumentBuilderInterface::class)  // \oat\tao\model\search\ServiceProvider
+                    service(IndexDocumentBuilderInterface::class)
                 ]
             )->public();
     }

--- a/model/Test/ServiceProvider/TestServiceProvider.php
+++ b/model/Test/ServiceProvider/TestServiceProvider.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\model\Test\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-use oat\tao\model\search\index\IndexService;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\taoAdvancedSearch\model\Test\Normalizer\TestNormalizer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use taoQtiTest_models_classes_QtiTestService;
@@ -43,7 +43,7 @@ class TestServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(taoQtiTest_models_classes_QtiTestService::class),
-                    service(IndexService::class)
+                    service(IndexDocumentBuilderInterface::class)  // \oat\tao\model\search\ServiceProvider
                 ]
             )->public();
     }

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -70,7 +70,7 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
             $report->add(Report::createSuccess('Total indexed "' . $data['index'] . '": ' . $totalIndexed));
             $report->add(
                 new Report(
-                    $this->getPercentageReportTypeBy($percentage, $totalIndexed),
+                    $this->getPercentageReportTypeBy($percentage, $missingIndex),
                     'Percentage indexed: ' . $percentage . '%'
                 )
             );
@@ -87,9 +87,9 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
         return $mainReport;
     }
 
-    private function getPercentageReportTypeBy(float $percentage, int $totalIndexed): string
+    private function getPercentageReportTypeBy(float $percentage, int $missingIndex): string
     {
-        if ($totalIndexed == 0) {
+        if ($missingIndex === 0) {
             return Report::TYPE_WARNING;
         }
 

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -89,7 +89,7 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
 
     private function getPercentageReportTypeBy(float $percentage, int $missingIndex): string
     {
-        if ($missingIndex === 0) {
+        if ($missingIndex === 0 && $percentage == 0) {
             return Report::TYPE_WARNING;
         }
 

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -68,8 +68,14 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
             $report = Report::createInfo($data['label']);
             $report->add(Report::createSuccess('Total in DB: ' . $data['totalInDb']));
             $report->add(Report::createSuccess('Total indexed "' . $data['index'] . '": ' . $totalIndexed));
-            $report->add(new Report($this->getPercentageReportTypeBy($percentage, $totalIndexed), 'Percentage indexed: ' . $percentage . '%'));
-            $report->add(new Report($missingIndex > 0 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS, 'Missing items: ' . $missingIndex));
+            $report->add(new Report(
+                $this->getPercentageReportTypeBy($percentage, $totalIndexed),
+                'Percentage indexed: ' . $percentage . '%')
+            );
+            $report->add(new Report(
+                $missingIndex > 0 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS,
+                'Missing items: ' . $missingIndex
+            ));
 
             $mainReport->add($report);
         }

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -70,7 +70,7 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
             $report->add(Report::createSuccess('Total indexed "' . $data['index'] . '": ' . $totalIndexed));
             $report->add(
                 new Report(
-                    $this->getPercentageReportTypeBy($percentage, $missingIndex),
+                    $this->getPercentageReportTypeBy($percentage, (int)$data['totalInDb']),
                     'Percentage indexed: ' . $percentage . '%'
                 )
             );
@@ -87,9 +87,9 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
         return $mainReport;
     }
 
-    private function getPercentageReportTypeBy(float $percentage, int $missingIndex): string
+    private function getPercentageReportTypeBy(float $percentage, int $totalInDB): string
     {
-        if ($missingIndex === 0 && $percentage == 0) {
+        if ($totalInDB === 0) {
             return Report::TYPE_WARNING;
         }
 

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -68,14 +68,18 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
             $report = Report::createInfo($data['label']);
             $report->add(Report::createSuccess('Total in DB: ' . $data['totalInDb']));
             $report->add(Report::createSuccess('Total indexed "' . $data['index'] . '": ' . $totalIndexed));
-            $report->add(new Report(
-                $this->getPercentageReportTypeBy($percentage, $totalIndexed),
-                'Percentage indexed: ' . $percentage . '%')
+            $report->add(
+                new Report(
+                    $this->getPercentageReportTypeBy($percentage, $totalIndexed),
+                    'Percentage indexed: ' . $percentage . '%'
+                )
             );
-            $report->add(new Report(
-                $missingIndex > 0 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS,
-                'Missing items: ' . $missingIndex
-            ));
+            $report->add(
+                new Report(
+                    $missingIndex > 0 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS,
+                    'Missing items: ' . $missingIndex
+                )
+            );
 
             $mainReport->add($report);
         }

--- a/scripts/tools/IndexSummary.php
+++ b/scripts/tools/IndexSummary.php
@@ -68,13 +68,26 @@ class IndexSummary extends ScriptAction implements ServiceLocatorAwareInterface
             $report = Report::createInfo($data['label']);
             $report->add(Report::createSuccess('Total in DB: ' . $data['totalInDb']));
             $report->add(Report::createSuccess('Total indexed "' . $data['index'] . '": ' . $totalIndexed));
-            $report->add(new Report($percentage < 100 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS, 'Percentage indexed: ' . $percentage . '%'));
+            $report->add(new Report($this->getPercentageReportTypeBy($percentage, $totalIndexed), 'Percentage indexed: ' . $percentage . '%'));
             $report->add(new Report($missingIndex > 0 ? Report::TYPE_ERROR : Report::TYPE_SUCCESS, 'Missing items: ' . $missingIndex));
 
             $mainReport->add($report);
         }
 
         return $mainReport;
+    }
+
+    private function getPercentageReportTypeBy(float $percentage, int $totalIndexed): string
+    {
+        if ($totalIndexed == 0) {
+            return Report::TYPE_WARNING;
+        }
+
+        if ($percentage < 100) {
+            return Report::TYPE_ERROR;
+        }
+
+        return Report::TYPE_SUCCESS;
     }
 
     private function getIndexSummarizer(): IndexSummarizer

--- a/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
+++ b/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
@@ -30,7 +30,6 @@ use oat\tao\model\media\TaoMediaResolver;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use oat\tao\model\TaoOntology;
 use oat\taoAdvancedSearch\model\Index\Service\AdvancedSearchIndexDocumentBuilder;
 use oat\taoAdvancedSearch\model\Test\Normalizer\TestNormalizer;
@@ -57,9 +56,6 @@ class AdvancedSearchIndexDocumentBuilderTest extends TestCase
 
     /** @var ElementReferencesExtractor|MockObject */
     private $elementReferencesExtractor;
-
-    /** @var IndexService|MockObject */
-    private $indexService;
 
     /** @var IndexDocumentBuilderInterface|MockObject */
     private $parentBuilder;
@@ -90,7 +86,6 @@ class AdvancedSearchIndexDocumentBuilderTest extends TestCase
         $this->document = $this->createMock(IndexDocument::class);
         $this->elementReferencesExtractor = $this->createMock(ElementReferencesExtractor::class);
         $this->idDiscoverService = $this->createMock(IdDiscoverService::class);
-        $this->indexService = $this->createMock(IndexService::class);
         $this->itemService = $this->createMock(QtiItemService::class);
         $this->parentBuilder = $this->createMock(IndexDocumentBuilder::class);
         $this->qtiItem = $this->createMock(Item::class);
@@ -102,15 +97,9 @@ class AdvancedSearchIndexDocumentBuilderTest extends TestCase
         $this->testType = $this->mockRDFClass(TaoOntology::CLASS_URI_TEST);
         $this->genericType = $this->mockRDFClass(TaoOntology::CLASS_URI_OBJECT);
 
-        $this->indexService
-            ->method('getDocumentBuilder')
-            ->willReturn($this->parentBuilder);
-
-        ServiceManager::setServiceManager($this->getServiceManagerMock());
-
         $this->sut = new AdvancedSearchIndexDocumentBuilder(
             $this->elementReferencesExtractor,
-            $this->indexService,
+            $this->parentBuilder,
             $this->idDiscoverService,
             $this->testNormalizer,
             $this->itemService,

--- a/tests/Unit/Index/Service/SyncResultIndexerTest.php
+++ b/tests/Unit/Index/Service/SyncResultIndexerTest.php
@@ -30,7 +30,7 @@ use oat\tao\model\search\SearchProxy;
 use oat\tao\model\task\migration\ResultUnit;
 use oat\taoAdvancedSearch\model\Index\IndexResource;
 use oat\taoAdvancedSearch\model\Index\Normalizer\NormalizerInterface;
-use oat\taoAdvancedSearch\model\Index\Service\ResultIndexer;
+use oat\taoAdvancedSearch\model\Index\Service\AdvancedSearchIndexDocumentBuilder;
 use oat\taoAdvancedSearch\model\Index\Service\SyncResultIndexer;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -60,7 +60,7 @@ class SyncResultIndexerTest extends TestCase
             $this->getServiceLocatorMock(
                 [
                     SearchProxy::SERVICE_ID => $this->search,
-                    IndexDocumentBuilderInterface::class => $this->indexDocumentBuilder,
+                    AdvancedSearchIndexDocumentBuilder::class => $this->indexDocumentBuilder,
                 ]
             )
         );

--- a/tests/Unit/Index/Service/SyncResultIndexerTest.php
+++ b/tests/Unit/Index/Service/SyncResultIndexerTest.php
@@ -25,7 +25,6 @@ namespace oat\taoAdvancedSearch\tests\Unit\Index\Service;
 use oat\generis\test\TestCase;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
 use oat\tao\model\task\migration\ResultUnit;
@@ -43,9 +42,6 @@ class SyncResultIndexerTest extends TestCase
     /** @var SyncResultIndexer */
     private $indexer;
 
-    /** @var IndexService|MockObject */
-    private $indexerService;
-
     /** @var SearchInterface|MockObject */
     private $search;
 
@@ -55,7 +51,6 @@ class SyncResultIndexerTest extends TestCase
     public function setUp(): void
     {
         $this->normalizer = $this->createMock(NormalizerInterface::class);
-        $this->indexerService = $this->createMock(IndexService::class);
         $this->search = $this->createMock(SearchInterface::class);
         $this->indexDocumentBuilder = $this->createMock(IndexDocumentBuilderInterface::class);
 
@@ -64,16 +59,11 @@ class SyncResultIndexerTest extends TestCase
         $this->indexer->setServiceLocator(
             $this->getServiceLocatorMock(
                 [
-                    IndexService::SERVICE_ID => $this->indexerService,
                     SearchProxy::SERVICE_ID => $this->search,
                     IndexDocumentBuilderInterface::class => $this->indexDocumentBuilder,
                 ]
             )
         );
-
-        $this->indexerService
-            ->method('getDocumentBuilder')
-            ->willReturn($this->indexDocumentBuilder);
     }
 
     public function testAddIndex(): void

--- a/tests/Unit/Test/Normalizer/TestNormalizerTest.php
+++ b/tests/Unit/Test/Normalizer/TestNormalizerTest.php
@@ -28,7 +28,6 @@ use oat\oatbox\service\ServiceManager;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexService;
 use oat\taoAdvancedSearch\model\Test\Normalizer\TestNormalizer;
 use PHPUnit\Framework\TestCase;
 use taoQtiTest_models_classes_QtiTestService as QtiTestService;
@@ -44,9 +43,6 @@ class TestNormalizerTest extends TestCase
     /** @var QtiTestService|MockObject */
     private $qtiTestService;
 
-    /** @var IndexService|MockObject */
-    private $indexService;
-
     /** @var IndexDocumentBuilderInterface|MockObject */
     private $documentBuilder;
 
@@ -57,16 +53,9 @@ class TestNormalizerTest extends TestCase
     {
         $this->document = $this->createMock(IndexDocument::class);
         $this->qtiTestService = $this->createMock(QtiTestService::class);
-        $this->indexService = $this->createMock(IndexService::class);
         $this->documentBuilder = $this->createMock(IndexDocumentBuilder::class);
 
-        $this->indexService
-            ->method('getDocumentBuilder')
-            ->willReturn($this->documentBuilder);
-
-        ServiceManager::setServiceManager($this->getServiceManagerMock());
-
-        $this->sut = new TestNormalizer($this->qtiTestService, $this->indexService);
+        $this->sut = new TestNormalizer($this->qtiTestService, $this->documentBuilder);
     }
 
     public function testNormalize(): void


### PR DESCRIPTION
**Associated Jira issue:** [PISA25-537](https://oat-sa.atlassian.net/browse/PISA25-537)

This PR aims to fix errors like `Error adding search index for https:\/\/pisa2025-qa.eu.premium.taocloud.org\/#i6502d9acb06b673550db49d035dff0cf28 with message ServiceLocator not initialized for oat\\tao\\model\\search\\index\\DocumentBuilder\\IndexDocumentBuilder`

What's done:
- Get rid of `IndexService` usage, using core `IndexDocumentBuilder` via DI container.
- Fixed type error `DeliveryResultRepository::getTotal()` - not related to the initial bug
- Improved IndexSummary report look - not related to the initial bug

Related PRs:
- https://github.com/oat-sa/tao-core/pull/3888


[PISA25-537]: https://oat-sa.atlassian.net/browse/PISA25-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ