### PR TITLE
[Backport][Fix] Use SH instead of BASH

### DIFF
--- a/scripts/tools/CacheWarmup.sh
+++ b/scripts/tools/CacheWarmup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then

--- a/scripts/tools/GarbageCollector.sh
+++ b/scripts/tools/GarbageCollector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then

--- a/scripts/tools/IndexClassMetadata.sh
+++ b/scripts/tools/IndexClassMetadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then

--- a/scripts/tools/IndexClassResources.sh
+++ b/scripts/tools/IndexClassResources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]

--- a/scripts/tools/IndexDeliveryResults.sh
+++ b/scripts/tools/IndexDeliveryResults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then

--- a/scripts/tools/IndexPopulator.sh
+++ b/scripts/tools/IndexPopulator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then

--- a/scripts/tools/IndexResources.sh
+++ b/scripts/tools/IndexResources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]
 then


### PR DESCRIPTION
# Backport for [ADF-1667](https://oat-sa.atlassian.net/browse/ADF-1667)

## Changes
* Shell scripts changes to use `#!/bin/sh` instead of `#!/bin/bash`

## Original PR
* https://github.com/oat-sa/extension-tao-advanced-search/pull/118

[ADF-1667]: https://oat-sa.atlassian.net/browse/ADF-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ