### PR TITLE
fix: the app only works with elastic 8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "oat-sa/extension-tao-outcome": ">=13.0.0",
     "oat-sa/extension-tao-test": ">=15.15.1",
     "oat-sa/extension-tao-mediamanager": ">=12.32.1",
-    "elasticsearch/elasticsearch": "^7.2|^8.0"
+    "elasticsearch/elasticsearch": "^8.0"
   },
   "require-dev": {
     "php-http/mock-client": "^1.6",


### PR DESCRIPTION
# Goal 

https://oat-sa.atlassian.net/browse/ADF-1774
https://oat-sa.atlassian.net/browse/AUT-3790

The current version of elastic lib 7.* is not compatible with the code, cause errors in update and installation such as: 

```
#20 /var/www/html/tao/models/classes/mvc/Bootstrap.php(189): oat\tao\model\mvc\Bootstrap->mvc()
#21 /var/www/html/tao/models/classes/mvc/Bootstrap.php(249): oat\tao\model\mvc\Bootstrap->dispatchHttp()
#22 /var/www/html/index.php(27): oat\tao\model\mvc\Bootstrap->dispatch()
#23 {main}
  thrown in /var/www/html/taoAdvancedSearch/model/SearchEngine/Driver/Elasticsearch/ElasticSearchClientFactory.php on line 42
2024-08-29 15:09:09 [ERROR] [tao] 'php error(1) in /var/www/html/taoAdvancedSearch/model/SearchEngine/Driver/Elasticsearch/ElasticSearchClientFactory.php@42: Uncaught Error: Class "Elastic\Elasticsearch\ClientBuilder" not found in /var/www/html/taoAdvancedSearch/model/SearchEngine/Driver/Elasticsearch/ElasticSearchClientFactory.php:42
Stack trace:
#0 /var/www/html/data/generis/cache/_di/container.php(329): oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchClientFactory->create()
#1 /var/www/html/data/generis/cache/_di
```