### PR TITLE
fix: add option for faster resource type item or test determination

### DIFF
--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -44,6 +44,8 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 {
     private const ASSETS_KEY = 'asset_uris';
     private const TEST_KEY = 'test_uri';
+    private const PROPERTY_MARKING_TEST = 'http://www.tao.lu/Ontologies/TAOTest.rdf#TestTestModel';
+    private const PROPERTY_MARKING_ITEM = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemModel';
 
     private ElementReferencesExtractor $itemElementReferencesExtractor;
     private QtiItemService $qtiItemService;
@@ -178,12 +180,42 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private function isA(string $type, core_kernel_classes_Resource $resource): bool
     {
+        if ($type === TaoOntology::CLASS_URI_TEST && $this->isTest($resource)) {
+            return true;
+        }
+
+        if ($type === TaoOntology::CLASS_URI_ITEM && $this->isItem($resource)) {
+            return true;
+        }
+
         $rootClass = $resource->getClass($type);
 
         foreach ($resource->getTypes() as $type) {
             if ($type->equals($rootClass) || $type->isSubClassOf($rootClass)) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    private function isTest(core_kernel_classes_Resource $resource): bool
+    {
+        if ($resource->getOnePropertyValue($resource->getProperty(
+            self::PROPERTY_MARKING_TEST
+        ))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function isItem(core_kernel_classes_Resource $resource): bool
+    {
+        if ($resource->getOnePropertyValue($resource->getProperty(
+            self::PROPERTY_MARKING_ITEM
+        ))) {
+            return true;
         }
 
         return false;

--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -201,27 +201,11 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private function isTest(core_kernel_classes_Resource $resource): bool
     {
-        if (
-            $resource->getOnePropertyValue($resource->getProperty(
-                self::PROPERTY_MARKING_TEST
-            ))
-        ) {
-            return true;
-        }
-
-        return false;
+        return !!$resource->getOnePropertyValue($resource->getProperty(self::PROPERTY_MARKING_TEST));
     }
 
     private function isItem(core_kernel_classes_Resource $resource): bool
     {
-        if (
-            $resource->getOnePropertyValue($resource->getProperty(
-                self::PROPERTY_MARKING_ITEM
-            ))
-        ) {
-            return true;
-        }
-
-        return false;
+        return !!$resource->getOnePropertyValue($resource->getProperty(self::PROPERTY_MARKING_ITEM));
     }
 }

--- a/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
+++ b/model/Index/Service/AdvancedSearchIndexDocumentBuilder.php
@@ -201,9 +201,11 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private function isTest(core_kernel_classes_Resource $resource): bool
     {
-        if ($resource->getOnePropertyValue($resource->getProperty(
-            self::PROPERTY_MARKING_TEST
-        ))) {
+        if (
+            $resource->getOnePropertyValue($resource->getProperty(
+                self::PROPERTY_MARKING_TEST
+            ))
+        ) {
             return true;
         }
 
@@ -212,9 +214,11 @@ class AdvancedSearchIndexDocumentBuilder implements IndexDocumentBuilderInterfac
 
     private function isItem(core_kernel_classes_Resource $resource): bool
     {
-        if ($resource->getOnePropertyValue($resource->getProperty(
-            self::PROPERTY_MARKING_ITEM
-        ))) {
+        if (
+            $resource->getOnePropertyValue($resource->getProperty(
+                self::PROPERTY_MARKING_ITEM
+            ))
+        ) {
             return true;
         }
 

--- a/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
+++ b/tests/Unit/Index/Service/AdvancedSearchIndexDocumentBuilderTest.php
@@ -306,6 +306,23 @@ class AdvancedSearchIndexDocumentBuilderTest extends TestCase
                 [TaoOntology::CLASS_URI_OBJECT, $this->genericType],
             ]);
 
+        $testProp = new \core_kernel_classes_Property(TaoOntology::CLASS_URI_TEST);
+        $itemProp = new \core_kernel_classes_Property(TaoOntology::CLASS_URI_ITEM);
+        $anItem
+            ->method('getProperty')
+            ->willReturnMap([
+                ['http://www.tao.lu/Ontologies/TAOTest.rdf#TestTestModel', $testProp],
+                ['http://www.tao.lu/Ontologies/TAOItem.rdf#ItemModel', $itemProp],
+            ]);
+
+        $anItem
+            ->method('getOnePropertyValue')
+            ->willReturnCallback(
+                function (\core_kernel_classes_Property $res) use ($types) {
+                    return in_array($res->getUri(), $types);
+                }
+            );
+
         return $anItem;
     }
 


### PR DESCRIPTION
This PR aims to avoid recursive class structure querying to identify resource type in the most cases.

Some background:
For translations we import a huge amount of test packages that triggers indexation and as well as we use nested and huge classes structure. It was found that at some point we have a huge frequently repeated query which stresses DB:
![image](https://github.com/user-attachments/assets/da03f480-12f7-448f-aeaf-8354319ce3ed)
