### PR TITLE
fix: fix connecting to elastic after updating elasticseach lib

### DIFF
--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchClientFactory.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchClientFactory.php
@@ -44,7 +44,7 @@ class ElasticSearchClientFactory
         if ($this->config->getElasticCloudId()) {
             return $clientBuilder
                 ->setElasticCloudId($this->config->getElasticCloudId())
-                ->setApiKey($this->config->getElasticCloudApiKeyId(), $this->config->getElasticCloudApiKey())
+                ->setApiKey($this->config->getElasticCloudApiKey(), $this->config->getElasticCloudApiKeyId())
                 ->build();
         }
 


### PR DESCRIPTION
Fixing connection to elastic after changes in the elasticsearch lib:
https://github.com/elastic/elasticsearch-php/blob/v7.17.0/src/Elasticsearch/ClientBuilder.php#L409
https://github.com/elastic/elasticsearch-php/blob/v8.15.0/src/ClientBuilder.php

```
old: setApiKey(string $id, string $apiKey)
new: setApiKey(string $apiKey, string $id = null)
```