### PR TITLE
feat/adf-1811/group-conditions-logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "ext-json": "*",
     "oat-sa/generis": ">=15.22",
-    "oat-sa/tao-core": "dev-feature/adf-1794/advanced-search-support as 99",
+    "oat-sa/tao-core": ">=54.24.0",
     "oat-sa/extension-tao-testqti": ">=48.11.0",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
     "oat-sa/extension-tao-outcome": ">=13.0.0",
-    "oat-sa/extension-tao-test": "dev-feature/adf-1794/advanced-search-support as 99",
+    "oat-sa/extension-tao-test": ">=16.4.0",
     "oat-sa/extension-tao-mediamanager": ">=12.32.1",
     "elasticsearch/elasticsearch": "^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
     "ext-json": "*",
     "oat-sa/generis": ">=15.22",
-    "oat-sa/tao-core": ">=54.21.0",
+    "oat-sa/tao-core": "dev-feature/adf-1794/advanced-search-support as 99",
     "oat-sa/extension-tao-testqti": ">=48.11.0",
     "oat-sa/extension-tao-delivery": ">=14.10.1",
     "oat-sa/extension-tao-outcome": ">=13.0.0",
-    "oat-sa/extension-tao-test": ">=15.15.1",
+    "oat-sa/extension-tao-test": "dev-feature/adf-1794/advanced-search-support as 99",
     "oat-sa/extension-tao-mediamanager": ">=12.32.1",
     "elasticsearch/elasticsearch": "^8.0"
   },

--- a/migrations/Version202106011320101488_taoAdvancedSearch.php
+++ b/migrations/Version202106011320101488_taoAdvancedSearch.php
@@ -14,7 +14,6 @@ use oat\taoTaskQueue\scripts\tools\BrokerFactory;
 
 final class Version202106011320101488_taoAdvancedSearch extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Adds task queue for indexation events.';
@@ -26,10 +25,15 @@ final class Version202106011320101488_taoAdvancedSearch extends AbstractMigratio
         $this->propagate($registrationService);
         $registrationService->__invoke([]);
 
-        if ( BrokerFactory::BROKER_MEMORY !== $this->getAssocitationService()->guessDefaultBrokerType()){
-            $this->addReport(Report::createWarning(
-                sprintf('New worker must be created to proceed tasks from queue named `%s`',$registrationService->getQueueName())
-            ));
+        if (BrokerFactory::BROKER_MEMORY !== $this->getAssocitationService()->guessDefaultBrokerType()) {
+            $this->addReport(
+                Report::createWarning(
+                    sprintf(
+                        'New worker must be created to proceed tasks from queue named `%s`',
+                        $registrationService->getQueueName()
+                    )
+                )
+            );
         }
     }
 

--- a/migrations/Version202209081525261488_taoAdvancedSearch.php
+++ b/migrations/Version202209081525261488_taoAdvancedSearch.php
@@ -35,7 +35,7 @@ final class Version202209081525261488_taoAdvancedSearch extends AbstractMigratio
 
         /** @var ServiceOptions $serviceOptions */
         $serviceOptions = $this->getServiceManager()->get(ServiceOptions::SERVICE_ID);
-        
+
         if ($oldElasticSearch) {
             $serviceOptions->save(ElasticSearchConfig::class, 'hosts', $oldElasticSearch->getOption('hosts'));
         }

--- a/model/Index/Report/IndexSummarizer.php
+++ b/model/Index/Report/IndexSummarizer.php
@@ -79,8 +79,7 @@ class IndexSummarizer extends ConfigurableService
         string $label,
         string $index,
         int $totalInDb
-    ): array
-    {
+    ): array {
         $totalIndexed = $this->getTotalResults($index);
         $percentageIndexed = $totalIndexed === 0 || $totalInDb === 0
             ? 0

--- a/model/Metadata/Listener/MetadataInheritanceListener.php
+++ b/model/Metadata/Listener/MetadataInheritanceListener.php
@@ -58,5 +58,4 @@ class MetadataInheritanceListener extends ConfigurableService implements Listene
         );
         return $indexer;
     }
-
 }

--- a/model/Metadata/Repository/ClassUriCachedRepository.php
+++ b/model/Metadata/Repository/ClassUriCachedRepository.php
@@ -29,10 +29,11 @@ use Psr\SimpleCache\CacheInterface;
 
 class ClassUriCachedRepository extends ConfigurableService implements ClassUriRepositoryInterface
 {
-    private const CLASSES_INDEX = self::class . '::CLASSES_URIS';
-    private const CLASSES_INDEX_TOTAL = self::class . '::CLASSES_URIS_TOTAL';
-
     use OntologyAwareTrait;
+
+    private const CLASSES_INDEX = self::class . '::CLASSES_URIS';
+
+    private const CLASSES_INDEX_TOTAL = self::class . '::CLASSES_URIS_TOTAL';
 
     public function cacheWarmup(): void
     {

--- a/model/Metadata/Service/AdvancedSearchSettingsService.php
+++ b/model/Metadata/Service/AdvancedSearchSettingsService.php
@@ -32,11 +32,15 @@ use oat\tao\model\Lists\Business\Input\ClassMetadataSearchInput;
 use oat\tao\model\search\Contract\SearchSettingsServiceInterface;
 use oat\tao\model\search\ResultColumn;
 use oat\tao\model\search\SearchSettings;
+use oat\tao\model\TaoOntology;
 
 class AdvancedSearchSettingsService implements SearchSettingsServiceInterface
 {
     private const OMIT_PROPERTIES = [
-        OntologyRdfs::RDFS_LABEL
+        OntologyRdfs::RDFS_LABEL,
+        TaoOntology::PROPERTY_TRANSLATION_TYPE,
+        TaoOntology::PROPERTY_TRANSLATION_PROGRESS,
+        TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI,
     ];
 
     public const DEFAULT_SORT_COLUMN = 'label.raw';

--- a/model/Metadata/Service/AdvancedSearchSettingsService.php
+++ b/model/Metadata/Service/AdvancedSearchSettingsService.php
@@ -72,7 +72,9 @@ class AdvancedSearchSettingsService implements SearchSettingsServiceInterface
                 ->getSettingsByClassMetadataSearchRequest($classMetadataSearchRequest);
         }
 
-        $classCollection = $this->classMetadataSearcher->findAll(new ClassMetadataSearchInput($classMetadataSearchRequest));
+        $classCollection = $this->classMetadataSearcher->findAll(
+            new ClassMetadataSearchInput($classMetadataSearchRequest)
+        );
 
         if ($classMetadataSearchRequest->getStructure() === 'results') {
             return new SearchSettings(

--- a/model/Metadata/Service/AdvancedSearchSettingsService.php
+++ b/model/Metadata/Service/AdvancedSearchSettingsService.php
@@ -27,7 +27,7 @@ namespace oat\taoAdvancedSearch\model\Metadata\Service;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
-use oat\tao\model\featureFlag\Service\FeatureBasedPropertiesService;
+use oat\tao\model\featureFlag\Service\FeatureFlagPropertiesMapping;
 use oat\tao\model\Lists\Business\Contract\ClassMetadataSearcherInterface;
 use oat\tao\model\Lists\Business\Domain\ClassMetadataSearchRequest;
 use oat\tao\model\Lists\Business\Input\ClassMetadataSearchInput;
@@ -53,20 +53,20 @@ class AdvancedSearchSettingsService implements SearchSettingsServiceInterface
 
     private SearchSettingsServiceInterface $defaultSearchSettingsService;
     private FeatureFlagCheckerInterface $featureFlagChecker;
-    private FeatureBasedPropertiesService $featureBasedPropertiesService;
+    private FeatureFlagPropertiesMapping $featureFlagPropertiesMapping;
 
     public function __construct(
         ClassMetadataSearcherInterface $classMetadataSearcher,
         SearchSettingsServiceInterface $defaultSearchSettingsService,
         AdvancedSearchChecker $advancedSearchChecker,
         FeatureFlagCheckerInterface $featureFlagChecker,
-        FeatureBasedPropertiesService $featureBasedPropertiesService
+        FeatureFlagPropertiesMapping $featureFlagPropertiesMapping
     ) {
         $this->classMetadataSearcher = $classMetadataSearcher;
         $this->advancedSearchChecker = $advancedSearchChecker;
         $this->defaultSearchSettingsService = $defaultSearchSettingsService;
         $this->featureFlagChecker = $featureFlagChecker;
-        $this->featureBasedPropertiesService = $featureBasedPropertiesService;
+        $this->featureFlagPropertiesMapping = $featureFlagPropertiesMapping;
     }
 
     public function getSettingsByClassMetadataSearchRequest(
@@ -208,7 +208,7 @@ class AdvancedSearchSettingsService implements SearchSettingsServiceInterface
     {
         $propertiesToHide = self::OMIT_PROPERTIES;
 
-        foreach ($this->featureBasedPropertiesService->getAllProperties() as $featureFlag => $properties) {
+        foreach ($this->featureFlagPropertiesMapping->getAllProperties() as $featureFlag => $properties) {
             if (!$this->featureFlagChecker->isEnabled($featureFlag)) {
                 foreach ($properties as $property) {
                     if (!in_array($property, $propertiesToHide, true)) {

--- a/model/Metadata/Service/ClassMetadataSearcher.php
+++ b/model/Metadata/Service/ClassMetadataSearcher.php
@@ -36,12 +36,19 @@ use oat\tao\model\Lists\Business\Service\ClassMetadataService;
 use oat\tao\model\Lists\Business\Service\GetClassMetadataValuesService;
 use oat\tao\model\search\ResultSet;
 use oat\tao\model\search\SearchProxy;
+use oat\tao\model\TaoOntology;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use oat\taoAdvancedSearch\model\SearchEngine\Query;
 
 class ClassMetadataSearcher extends ConfigurableService implements ClassMetadataSearcherInterface
 {
     private const BASE_LIST_ITEMS_URI = '/tao/PropertyValues/get?propertyUri=%s';
+
+    private const UNACCEPTABLE_PROPERTIES = [
+        TaoOntology::PROPERTY_TRANSLATION_TYPE,
+        TaoOntology::PROPERTY_TRANSLATION_PROGRESS,
+        TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI,
+    ];
 
     use OntologyAwareTrait;
 
@@ -89,8 +96,9 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
         $allProperties = [$result];
         $allProperties = $this->getRelatedProperties($result, $allProperties);
         $allProperties = $this->getClassPathProperties($classUri, $allProperties);
+        $allProperties = $this->filterDuplicatedProperties($allProperties);
 
-        return $this->filterDuplicatedProperties($allProperties);
+        return array_diff_key($allProperties, array_flip(self::UNACCEPTABLE_PROPERTIES));
     }
 
     private function getClassPathProperties(string $classUri, array $allProperties): array

--- a/model/Metadata/Service/ClassMetadataSearcher.php
+++ b/model/Metadata/Service/ClassMetadataSearcher.php
@@ -28,7 +28,7 @@ use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
-use oat\tao\model\featureFlag\Service\FeatureBasedPropertiesService;
+use oat\tao\model\featureFlag\Service\FeatureFlagPropertiesMapping;
 use oat\tao\model\Lists\Business\Contract\ClassMetadataSearcherInterface;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
 use oat\tao\model\Lists\Business\Domain\ClassMetadata;
@@ -276,7 +276,7 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
         $propertiesToHide = self::UNACCEPTABLE_PROPERTIES;
         $featureFlagChecker = $this->getFeatureFlagChecker();
 
-        foreach ($this->getFeatureBasedPropertiesService()->getAllProperties() as $featureFlag => $properties) {
+        foreach ($this->getFeatureFlagPropertiesMapping()->getAllProperties() as $featureFlag => $properties) {
             if (!$featureFlagChecker->isEnabled($featureFlag)) {
                 foreach ($properties as $property) {
                     if (!in_array($property, $propertiesToHide, true)) {
@@ -309,9 +309,9 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
         return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
     }
 
-    private function getFeatureBasedPropertiesService(): FeatureBasedPropertiesService
+    private function getFeatureFlagPropertiesMapping(): FeatureFlagPropertiesMapping
     {
-        return $this->getServiceLocator()->getContainer()->get(FeatureBasedPropertiesService::class);
+        return $this->getServiceLocator()->getContainer()->get(FeatureFlagPropertiesMapping::class);
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface

--- a/model/Metadata/Service/ClassMetadataSearcher.php
+++ b/model/Metadata/Service/ClassMetadataSearcher.php
@@ -42,6 +42,8 @@ use oat\taoAdvancedSearch\model\SearchEngine\Query;
 
 class ClassMetadataSearcher extends ConfigurableService implements ClassMetadataSearcherInterface
 {
+    use OntologyAwareTrait;
+
     private const BASE_LIST_ITEMS_URI = '/tao/PropertyValues/get?propertyUri=%s';
 
     private const UNACCEPTABLE_PROPERTIES = [
@@ -49,8 +51,6 @@ class ClassMetadataSearcher extends ConfigurableService implements ClassMetadata
         TaoOntology::PROPERTY_TRANSLATION_PROGRESS,
         TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI,
     ];
-
-    use OntologyAwareTrait;
 
     public function findAll(ClassMetadataSearchInput $input): ClassCollection
     {

--- a/model/Metadata/ServiceProvider/MetadataServiceProvider.php
+++ b/model/Metadata/ServiceProvider/MetadataServiceProvider.php
@@ -32,6 +32,7 @@ use oat\taoAdvancedSearch\model\Metadata\Service\ListSavedEventListener;
 use oat\taoAdvancedSearch\model\Metadata\Specification\PropertyAllowedSpecification;
 use oat\taoAdvancedSearch\model\Resource\Service\ResourceIndexer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 

--- a/model/Metadata/ServiceProvider/MetadataServiceProvider.php
+++ b/model/Metadata/ServiceProvider/MetadataServiceProvider.php
@@ -26,7 +26,7 @@ use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\persistence\PersistenceServiceProvider;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
-use oat\tao\model\featureFlag\Service\FeatureBasedPropertiesService;
+use oat\tao\model\featureFlag\Service\FeatureFlagPropertiesMapping;
 use oat\tao\model\Lists\Business\Service\ClassMetadataSearcherProxy;
 use oat\tao\model\search\Service\DefaultSearchSettingsService;
 use oat\taoAdvancedSearch\model\Metadata\Service\AdvancedSearchSettingsService;
@@ -63,7 +63,7 @@ class MetadataServiceProvider implements ContainerServiceProviderInterface
                     service(DefaultSearchSettingsService::class),
                     service(AdvancedSearchChecker::class),
                     service(FeatureFlagChecker::class),
-                    service(FeatureBasedPropertiesService::class),
+                    service(FeatureFlagPropertiesMapping::class),
                 ]
             )->public();
 

--- a/model/Metadata/ServiceProvider/MetadataServiceProvider.php
+++ b/model/Metadata/ServiceProvider/MetadataServiceProvider.php
@@ -25,6 +25,8 @@ namespace oat\taoAdvancedSearch\model\Metadata\ServiceProvider;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\persistence\PersistenceServiceProvider;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\Service\FeatureBasedPropertiesService;
 use oat\tao\model\Lists\Business\Service\ClassMetadataSearcherProxy;
 use oat\tao\model\search\Service\DefaultSearchSettingsService;
 use oat\taoAdvancedSearch\model\Metadata\Service\AdvancedSearchSettingsService;
@@ -60,6 +62,8 @@ class MetadataServiceProvider implements ContainerServiceProviderInterface
                     service(ClassMetadataSearcherProxy::SERVICE_ID),
                     service(DefaultSearchSettingsService::class),
                     service(AdvancedSearchChecker::class),
+                    service(FeatureFlagChecker::class),
+                    service(FeatureBasedPropertiesService::class),
                 ]
             )->public();
 

--- a/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
+++ b/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
@@ -148,7 +148,7 @@ trait LogIndexOperationsTrait
         LoggerInterface $logger,
         Throwable $e,
         string $method,
-        string $script='',
+        string $script = '',
         $type = null,
         array $query = []
     ): void {

--- a/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
+++ b/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
@@ -80,6 +80,7 @@ class QueryBuilder
         'RadioBox',
         'SearchTextBox',
         'SearchDropdown',
+        'Readonly',
     ];
 
     private const LOGIC_MODIFIERS = [

--- a/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
+++ b/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
@@ -214,8 +214,9 @@ class QueryBuilder
         return $this->getResourceConditions($blocks);
     }
 
-    private function containsLogicalModifier(string $block) {
-        foreach (self::LOGIC_MODIFIERS => $logicModifier) {
+    private function containsLogicalModifier(string $block): bool
+    {
+        foreach (self::LOGIC_MODIFIERS as $logicModifier) {
             if (strpos($block, $logicModifier) !== false) {
                 return true;
             }
@@ -224,66 +225,66 @@ class QueryBuilder
         return false;
     }
 
-    private function buildLogicCondition(string $block): ?string {
+    private function buildLogicCondition(string $block): ?string
+    {
         if (strpos($block, self::LOGIC_MODIFIERS['and']) !== false) {
-            $logicBlocks = preg_split('/( '.self::LOGIC_MODIFIERS['and'].' )/i', $block);
+            $logicBlocks = preg_split('/( ' . self::LOGIC_MODIFIERS['and'] . ' )/i', $block);
             $conditions = array_map([$this, 'buildConditionFromTheBlock'], $logicBlocks);
-            
+
             return sprintf('(%s)', implode(' AND ', $conditions));
         }
-        
+
         if (strpos($block, self::LOGIC_MODIFIERS['or']) !== false) {
-            $logicBlocks = preg_split('/( '.self::LOGIC_MODIFIERS['or'].' )/i', $block);
+            $logicBlocks = preg_split('/( ' . self::LOGIC_MODIFIERS['or'] . ' )/i', $block);
             $conditions = array_map([$this,'buildConditionFromTheBlock'], $logicBlocks);
 
             return sprintf('(%s)', implode(' OR ', $conditions));
-        } 
-        
+        }
+
         if (strpos($block, self::LOGIC_MODIFIERS['not']) !== false) {
             $logicBlocks = preg_split('/( ' . self::LOGIC_MODIFIERS['not'] . ' )/i', $block);
             $conditions = array_map([$this,'buildConditionFromTheBlock'], $logicBlocks);
 
             return sprintf('NOT (%s)', implode(' OR ', $conditions));
         }
-        
+
         return null;
     }
-        
 
     private function getResourceConditions(array $blocks): array
     {
-        
+
         $conditions = [];
 
         foreach ($blocks as $block) {
-            
-            if($this->containsLogicalModifier($block)) {
+            if ($this->containsLogicalModifier($block)) {
                 $conditions[] =  $this->buildLogicCondition($block);
-            }else{
+            } else {
                 $conditions[] =  $this->buildConditionFromTheBlock($block);
-            }    
-        }    
+            }
+        }
 
         return $conditions;
-    }    
-
-
-    private function buildConditionFromTheBlock(string $block) {
-        $queryBlock = $this->parseBlock($block);
-        $condition = '';
-        if (empty($queryBlock->getField())) {
-            $condition = sprintf('("%s")', $queryBlock->getTerm());
-        } elseif ($this->isStandardField($queryBlock->getField())) {
-            $condition = sprintf('(%s:"%s")', $queryBlock->getField(), $queryBlock->getTerm());
-        } else {
-            $condition = $this->buildCustomConditions($queryBlock);
-        }
-        return $condition;
     }
+
+    private function buildConditionFromTheBlock(string $block): string
+    {
+        $queryBlock = $this->parseBlock($block);
+        if (empty($queryBlock->getField())) {
+            return sprintf('("%s")', $queryBlock->getTerm());
+        } elseif ($this->isStandardField($queryBlock->getField())) {
+            return sprintf('(%s:"%s")', $queryBlock->getField(), $queryBlock->getTerm());
+        } else {
+            return $this->buildCustomConditions($queryBlock);
+        }
+        return '';
+    }
+
     private function isStandardField(string $field): bool
     {
         return in_array(strtolower($field), self::STANDARD_FIELDS);
     }
+
 
     private function getIndexByType(string $type): string
     {

--- a/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
+++ b/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
@@ -224,22 +224,29 @@ class QueryBuilder
         return false;
     }
 
-    private function buildLogicCondition(string $block) {
-        $condition = '';
-        if(strpos($block, self::LOGIC_MODIFIERS['and'])) {
+    private function buildLogicCondition(string $block): ?string {
+        if (strpos($block, self::LOGIC_MODIFIERS['and']) !== false) {
             $logicBlocks = preg_split('/( '.self::LOGIC_MODIFIERS['and'].' )/i', $block);
             $conditions = array_map([$this, 'buildConditionFromTheBlock'], $logicBlocks);
-            $condition = sprintf('(%s)', implode(' AND ', $conditions));
-        } elseif (strpos($block, self::LOGIC_MODIFIERS['or'])) {
+            
+            return sprintf('(%s)', implode(' AND ', $conditions));
+        }
+        
+        if (strpos($block, self::LOGIC_MODIFIERS['or']) !== false) {
             $logicBlocks = preg_split('/( '.self::LOGIC_MODIFIERS['or'].' )/i', $block);
             $conditions = array_map([$this,'buildConditionFromTheBlock'], $logicBlocks);
-            $condition = sprintf('(%s)', implode(' OR ', $conditions));
-        } elseif (strpos($block, self::LOGIC_MODIFIERS['not'])) {
+
+            return sprintf('(%s)', implode(' OR ', $conditions));
+        } 
+        
+        if (strpos($block, self::LOGIC_MODIFIERS['not']) !== false) {
             $logicBlocks = preg_split('/( ' . self::LOGIC_MODIFIERS['not'] . ' )/i', $block);
             $conditions = array_map([$this,'buildConditionFromTheBlock'], $logicBlocks);
-            $condition = sprintf('NOT (%s)', implode(' OR ', $conditions));
+
+            return sprintf('NOT (%s)', implode(' OR ', $conditions));
         }
-        return $condition;
+        
+        return null;
     }
         
 

--- a/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
+++ b/model/SearchEngine/Driver/Elasticsearch/QueryBuilder.php
@@ -215,14 +215,13 @@ class QueryBuilder
     }
 
     private function containsLogicalModifier(string $block) {
-        $found = false;
-        foreach(self::LOGIC_MODIFIERS as $key => $logicModifier) {
-            if(strpos($block, $logicModifier) !== false) {
-                $found = true;
-                break;
-            }    
-        }    
-        return $found;
+        foreach (self::LOGIC_MODIFIERS => $logicModifier) {
+            if (strpos($block, $logicModifier) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function buildLogicCondition(string $block) {

--- a/scripts/tools/CacheWarmup.php
+++ b/scripts/tools/CacheWarmup.php
@@ -76,7 +76,10 @@ class CacheWarmup extends ScriptAction implements ServiceLocatorAwareInterface
 
         $report->add(
             Report::createSuccess(
-                sprintf('Cache warmed up! ROOT classUris (%s) in cache', implode(', ', $indexableClassRepository->findAllUris()))
+                sprintf(
+                    'Cache warmed up! ROOT classUris (%s) in cache',
+                    implode(', ', $indexableClassRepository->findAllUris())
+                )
             )
         );
 

--- a/scripts/uninstall/UnRegisterTaskQueueServices.php
+++ b/scripts/uninstall/UnRegisterTaskQueueServices.php
@@ -39,8 +39,8 @@ class UnRegisterTaskQueueServices extends InstallAction
         return new Report(Report::TYPE_SUCCESS, 'Indexation TaskQueue `%s` was unregistered', $queueName);
     }
 
-    private function getAssociationService(): QueueAssociationService{
+    private function getAssociationService(): QueueAssociationService
+    {
         return $this->getServiceManager()->get(QueueAssociationService::class);
     }
-
 }

--- a/tests/Unit/Metadata/Service/AdvancedSearchSettingsServiceTest.php
+++ b/tests/Unit/Metadata/Service/AdvancedSearchSettingsServiceTest.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\tests\Unit\model\Metadata\Service;
 
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\tao\model\featureFlag\Service\FeatureFlagPropertiesMapping;
 use oat\tao\model\Lists\Business\Contract\ClassMetadataSearcherInterface;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
 use oat\tao\model\Lists\Business\Domain\ClassMetadata;
@@ -56,10 +58,19 @@ class AdvancedSearchSettingsServiceTest extends TestCase
         $this->classMetadataSearcher = $this->createMock(ClassMetadataSearcherInterface::class);
         $this->defaultSearchSettingsService = $this->createMock(SearchSettingsServiceInterface::class);
         $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
+        $featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
+        $featureFlagPropertiesMapping = $this->createMock(FeatureFlagPropertiesMapping::class);
+
+        $featureFlagPropertiesMapping
+            ->method('getAllProperties')
+            ->willReturn([]);
+
         $this->subject = new AdvancedSearchSettingsService(
             $this->classMetadataSearcher,
             $this->defaultSearchSettingsService,
-            $this->advancedSearchChecker
+            $this->advancedSearchChecker,
+            $featureFlagChecker,
+            $featureFlagPropertiesMapping
         );
     }
 

--- a/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
+++ b/tests/Unit/Metadata/Service/ClassMetadataSearcherTest.php
@@ -27,6 +27,9 @@ use oat\generis\model\data\Ontology;
 use oat\generis\test\ServiceManagerMockTrait;
 use oat\oatbox\log\LoggerService;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\tao\model\featureFlag\Service\FeatureFlagPropertiesMapping;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
 use oat\tao\model\Lists\Business\Domain\ClassMetadataSearchRequest;
 use oat\tao\model\Lists\Business\Domain\MetadataCollection;
@@ -74,6 +77,11 @@ class ClassMetadataSearcherTest extends TestCase
             ->method('getAdvancedSearch')
             ->willReturn($this->elasticSearch);
 
+        $featureFlagPropertiesMapping = $this->createMock(FeatureFlagPropertiesMapping::class);
+        $featureFlagPropertiesMapping
+            ->method('getAllProperties')
+            ->willReturn([]);
+
         $this->subject = new ClassMetadataSearcher();
         $this->subject->setServiceManager(
             $this->getServiceManagerMock(
@@ -82,7 +90,9 @@ class ClassMetadataSearcherTest extends TestCase
                     AdvancedSearchChecker::class => $this->advancedSearchChecker,
                     SearchProxy::SERVICE_ID => $this->search,
                     LoggerService::SERVICE_ID => $this->createMock(LoggerService::class),
-                    Ontology::SERVICE_ID => $this->ontology
+                    Ontology::SERVICE_ID => $this->ontology,
+                    FeatureFlagChecker::class => $this->createMock(FeatureFlagCheckerInterface::class),
+                    FeatureFlagPropertiesMapping::class => $featureFlagPropertiesMapping,
                 ]
             )
         );

--- a/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
+++ b/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
@@ -243,6 +243,57 @@ class QueryBuilderTest extends TestCase
                 '"missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last",' .
                 '"unmapped_type":"long"}}}'
             ],
+            'Query using OR logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_OR custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
+            'Query using AND logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_AND custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
+            'Query using NOT logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_NOT custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
+                '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
             'Query URIs' => [
                 'https://test-act.docker.localhost/ontologies/tao.rdf#i5f200ed20e80a8c259ebe410db7f6a',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(\"https:\/\/test-act.docker.localhost\/' .
@@ -383,6 +434,48 @@ class QueryBuilderTest extends TestCase
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\"' .
                 ' OR RadioBox_custom_field:\"test\" ' .
                 'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
+            'Query using OR logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_OR custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
+            'Query using AND logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_AND custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
+                '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
+                ':"_last","unmapped_type":"long"}}}',
+            ],
+            'Query using NOT logic operator to join list field values' => [
+                'label:test AND custom_field:test LOGIC_NOT custom_field:test1 ',
+                '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
+                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
+                'OR RadioBox_custom_field:\"test\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
+                ' OR RadioBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
                 '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
                 ':"_last","unmapped_type":"long"}}}',
             ],

--- a/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
+++ b/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
@@ -249,8 +249,9 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
@@ -266,8 +267,9 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
@@ -280,11 +282,14 @@ class QueryBuilderTest extends TestCase
             'Query using NOT logic operator to join list field values' => [
                 'label:test AND custom_field:test LOGIC_NOT custom_field:test1 ',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
-                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" ' .
+                'OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" ' .
+                'OR SearchDropdown_custom_field:\"test\") ' .
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
@@ -443,8 +448,9 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
@@ -457,8 +463,9 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
@@ -468,11 +475,13 @@ class QueryBuilderTest extends TestCase
             'Query using NOT logic operator to join list field values' => [
                 'label:test AND custom_field:test LOGIC_NOT custom_field:test1 ',
                 '{"query":{"query_string":{"default_operator":"AND","query":"(label:\"test\") AND ' .
-                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
+                'NOT ((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" ' .
+                'OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") '. 
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
+                'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
                 'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .

--- a/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
+++ b/tests/Unit/SearchEngine/Driver/Elasticsearch/QueryBuilderTest.php
@@ -160,8 +160,8 @@ class QueryBuilderTest extends TestCase
                 '\\"test\\" OR TextArea_custom_field:\\"test\\" OR ' .
                 'TextBox_custom_field:\\"test\\" OR ComboBox_custom_field:\\"test\\" ' .
                 'OR CheckBox_custom_field:\\"test\\" OR RadioBox_custom_field:\\"test\\" ' .
-                'OR SearchTextBox_custom_field:\\"test\\" OR SearchDropdown_custom_field:\\"test\\")' .
-                ' AND (read_access:(\\"https:\\/\\/tao.docker.localhost\\/' .
+                'OR SearchTextBox_custom_field:\\"test\\" OR SearchDropdown_custom_field:\\"test\\" ' .
+                'OR Readonly_custom_field:\\"test\\") AND (read_access:(\\"https:\\/\\/tao.docker.localhost\\/' .
                 'ontologies\\/tao.rdf#i5f64514f1c36110793759fc28c0105b\\" OR \\"http:\\/\\/www.tao.lu\\/Ontologies\\/' .
                 'TAOItem.rdf#BackOfficeRole\\" OR ' .
                 '\\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#ItemsManagerRole\\"))"}},' .
@@ -174,8 +174,8 @@ class QueryBuilderTest extends TestCase
                 '(HTMLArea_custom_field:\\"test\\" OR TextArea_custom_field:\\"test\\" OR ' .
                 'TextBox_custom_field:\\"test\\" OR ComboBox_custom_field:\\"test\\"' .
                 ' OR CheckBox_custom_field:\\"test\\" OR RadioBox_custom_field:\\"test\\" ' .
-                'OR SearchTextBox_custom_field:\\"test\\" OR SearchDropdown_custom_field:\\' .
-                '"test\\") AND (read_access:(\\"https:\\/\\/tao.docker.localhost\\/' .
+                'OR SearchTextBox_custom_field:\\"test\\" OR SearchDropdown_custom_field:\\"test\\" ' .
+                'OR Readonly_custom_field:\\"test\\") AND (read_access:(\\"https:\\/\\/tao.docker.localhost\\/' .
                 'ontologies\\/tao.rdf#i5f64514f1c36110793759fc28c0105b\\" OR ' .
                 '\\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#BackOfficeRole\\" OR ' .
                 '\\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#ItemsManagerRole\\"))"}},' .
@@ -191,8 +191,8 @@ class QueryBuilderTest extends TestCase
                     'field:\"test\" OR ComboBox_custom field:\"test\" ' .
                     'OR CheckBox_custom field:\"test\" OR RadioBox_custom ' .
                     'field:\"test\" OR SearchTextBox_custom field:\"test\" ' .
-                    'OR SearchDropdown_custom field:\"test\") AND ' .
-                    '(read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf' .
+                    'OR SearchDropdown_custom field:\"test\" OR Readonly_custom field:\\"test\\")' .
+                    ' AND (read_access:(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf' .
                     '#i5f64514f1c36110793759fc28c0105b\" OR ' .
                     '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" ' .
                     'OR \"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},' .
@@ -207,7 +207,8 @@ class QueryBuilderTest extends TestCase
                 'field:\\"test\\" OR TextBox_custom_field:\\"test\\" OR ' .
                 'ComboBox_custom_field:\\"test\\" OR CheckBox_custom_field:\\"test\\" OR RadioBox_' .
                 'custom_field:\\"test\\" OR SearchTextBox_custom_field:\\"test\\" ' .
-                'OR SearchDropdown_custom_field:\\"test\\") AND (read_access:(\\"https:\\/' .
+                'OR SearchDropdown_custom_field:\\"test\\" OR Readonly_custom_field:\\"test\\")' .
+                ' AND (read_access:(\\"https:\\/' .
                 '\\/tao.docker.localhost\\/ontologies\\/tao.rdf#i5f64514f1c36110793759fc28c0105b\\"' .
                 ' OR \\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#' .
                 'BackOfficeRole\\" OR \\"http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#ItemsManagerRole\\"))"}}' .
@@ -221,7 +222,8 @@ class QueryBuilderTest extends TestCase
                 '(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") AND (read_access:' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") AND (read_access:' .
                 '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},' .
@@ -235,7 +237,8 @@ class QueryBuilderTest extends TestCase
                 '(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\"' .
                 ' OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") AND (read_access:' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") AND (read_access:' .
                 '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},' .
@@ -249,12 +252,14 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") ' .
                 'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
                 'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\" ' .
+                'OR Readonly_custom_field:\"test1\")) AND (read_access:' .
                 '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
@@ -267,12 +272,14 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") ' .
                 'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
                 'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\" ' .
+                'OR Readonly_custom_field:\"test1\")) AND (read_access:' .
                 '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
@@ -287,12 +294,13 @@ class QueryBuilderTest extends TestCase
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
                 'OR SearchTextBox_custom_field:\"test\" ' .
-                'OR SearchDropdown_custom_field:\"test\") ' .
+                'OR SearchDropdown_custom_field:\"test\" OR Readonly_custom_field:\"test\") ' .
                 'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
                 'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\")) AND (read_access:' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\" ' .
+                'OR Readonly_custom_field:\"test1\")) AND (read_access:' .
                 '(\"https:\/\/tao.docker.localhost\/ontologies\/tao.rdf#i5f64514f1c36110793759fc28c0105b\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#BackOfficeRole\" OR ' .
                 '\"http:\/\/www.tao.lu\/Ontologies\/TAOItem.rdf#ItemsManagerRole\"))"}},"sort":{"_id":' .
@@ -391,7 +399,7 @@ class QueryBuilderTest extends TestCase
                 ':\"test\" OR ComboBox_custom_field:\"test\" ' .
                 'OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:' .
                 '\"test\" OR SearchTextBox_custom_field:\"test\" ' .
-                'OR SearchDropdown_custom_field:\"test\")"}},' .
+                'OR SearchDropdown_custom_field:\"test\" OR Readonly_custom_field:\"test\")"}},' .
                 '"sort":{"_id":{"order":"DESC","missing":"_last",' .
                 '"unmapped_type":"long"},"label.raw":{"order":' .
                 '"DESC","missing":"_last","unmapped_type":"long"}}}'
@@ -401,8 +409,8 @@ class QueryBuilderTest extends TestCase
                 '{"query":{"query_string":{"default_operator":"AND","query":"(HTMLArea_custom_field:\"test\" OR ' .
                 'TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" ' .
                 'OR CheckBox_custom_field:\"test\" OR RadioBox_custom_field:' .
-                '\"test\" OR SearchTextBox_custom_field:\"test\" ' .
-                'OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last",' .
+                '\"test\" OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last",' .
                 '"unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last","unmapped_type":"long"}}}'
             ],
             'Query custom field (using space)' => [
@@ -411,8 +419,8 @@ class QueryBuilderTest extends TestCase
                     'field:\"test\" OR TextArea_custom field:\"test\" OR TextBox_custom field:\"test\" ' .
                     'OR ComboBox_custom field:\"test\" OR CheckBox_custom field:\"test\" OR RadioBox_custom ' .
                     'field:\"test\" OR SearchTextBox_custom field:\"test\" OR SearchDropdown_custom field:' .
-                    '\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last","unmapped_type":"long"},' .
-                    '"label.raw":{"order":"DESC","missing":"_last","unmapped_type":"long"}}}',
+                    '\"test\" OR Readonly_custom field:\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last",' .
+                    '"unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last","unmapped_type":"long"}}}',
             ],
             'Query logic operator (Uppercase)' => [
                 'label:test AND custom_field:test',
@@ -420,8 +428,9 @@ class QueryBuilderTest extends TestCase
                 'AND (HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR ' .
                 'TextBox_custom_field:\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:' .
                 '\"test\" OR RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR ' .
-                'SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last"' .
-                ',"unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last","unmapped_type":"long"}}}',
+                'SearchDropdown_custom_field:\"test\" OR Readonly_custom_field:\"test\")"}},"sort":{"_id":{"order":' .
+                '"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last",' .
+                '"unmapped_type":"long"}}}',
             ],
             'Query logic operator (Lowercase)' => [
                 'label:test and custom_field:test',
@@ -429,8 +438,9 @@ class QueryBuilderTest extends TestCase
                 '(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:' .
                 '\"test\" OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" OR ' .
                 'RadioBox_custom_field:\"test\" OR SearchTextBox_custom_field:\"test\" OR ' .
-                'SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":{"order":"DESC","missing":"_last",' .
-                '"unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last","unmapped_type":"long"}}}',
+                'SearchDropdown_custom_field:\"test\" OR Readonly_custom_field:\"test\")"}},"sort":{"_id":{"order":' .
+                '"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing":"_last",' .
+                '"unmapped_type":"long"}}}',
             ],
             'Query logic operator (Mixed)' => [
                 'label:test aNd custom_field:test',
@@ -438,7 +448,8 @@ class QueryBuilderTest extends TestCase
                 '(HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\"' .
                 ' OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\")"}},"sort":{"_id":' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\")"}},"sort":{"_id":' .
                 '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
                 ':"_last","unmapped_type":"long"}}}',
             ],
@@ -448,12 +459,12 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
-                'OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") OR (HTMLArea_custom_field:\"test1\" ' .
+                'OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
-                ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
+                ' OR RadioBox_custom_field:\"test1\" OR SearchTextBox_custom_field:\"test1\" ' .
+                'OR SearchDropdown_custom_field:\"test1\" OR Readonly_custom_field:\"test1\"))"}},"sort":{"_id":' .
                 '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
                 ':"_last","unmapped_type":"long"}}}',
             ],
@@ -463,12 +474,14 @@ class QueryBuilderTest extends TestCase
                 '((HTMLArea_custom_field:\"test\" OR TextArea_custom_field:\"test\" OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") ' .
                 'AND (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
                 'OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\" ' .
+                'OR Readonly_custom_field:\"test1\"))"}},"sort":{"_id":' .
                 '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
                 ':"_last","unmapped_type":"long"}}}',
             ],
@@ -479,12 +492,13 @@ class QueryBuilderTest extends TestCase
                 'OR TextBox_custom_field:\"test\" ' .
                 'OR ComboBox_custom_field:\"test\" OR CheckBox_custom_field:\"test\" ' .
                 'OR RadioBox_custom_field:\"test\" ' .
-                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\") ' .
-                'OR (HTMLArea_custom_field:\"test1\" OR TextArea_custom_field:\"test1\" ' .
-                'OR TextBox_custom_field:\"test1\" ' .
+                'OR SearchTextBox_custom_field:\"test\" OR SearchDropdown_custom_field:\"test\" ' .
+                'OR Readonly_custom_field:\"test\") OR (HTMLArea_custom_field:\"test1\" ' .
+                'OR TextArea_custom_field:\"test1\" OR TextBox_custom_field:\"test1\" ' .
                 'OR ComboBox_custom_field:\"test1\" OR CheckBox_custom_field:\"test1\"' .
                 ' OR RadioBox_custom_field:\"test1\" ' .
-                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\"))"}},"sort":{"_id":' .
+                'OR SearchTextBox_custom_field:\"test1\" OR SearchDropdown_custom_field:\"test1\" ' .
+                'OR Readonly_custom_field:\"test1\"))"}},"sort":{"_id":' .
                 '{"order":"DESC","missing":"_last","unmapped_type":"long"},"label.raw":{"order":"DESC","missing"' .
                 ':"_last","unmapped_type":"long"}}}',
             ],


### PR DESCRIPTION
related to:

- https://oat-sa.atlassian.net/browse/ADF-1811
- https://oat-sa.atlassian.net/browse/ADF-1794

### Description

This PR is BE counterpart of https://github.com/oat-sa/tao-core-ui-fe/pull/605

searchModal with the advancedSearch supplies logical combinators for list fields which then are parsed and transformed into elasticsearchquery on backend. This PR implements AND, OR, NOT logic.

### How to test

 - unit tests
 - setup advancedSearch, set tao-core-ui in tao to the branch `feat/ADF-1811/group-conditions-logic`
 - add field to item/test schema with multiselect list property
 - apply combination logic to the selected values in searchModal