### PR TITLE
feat: remove FEATURE_FLAG_ITEM_RELATION_ON_DELETE

### DIFF
--- a/model/Resource/Service/ItemClassRelationService.php
+++ b/model/Resource/Service/ItemClassRelationService.php
@@ -25,7 +25,6 @@ namespace oat\taoAdvancedSearch\model\Resource\Service;
 use common_Logger;
 use oat\generis\model\data\Ontology;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\resources\relation\FindAllQuery;
 use oat\tao\model\resources\relation\ResourceRelation;
 use oat\tao\model\resources\relation\ResourceRelationCollection;
@@ -43,27 +42,21 @@ class ItemClassRelationService implements ResourceRelationServiceInterface
     private ElasticSearch $elasticSearch;
     private AdvancedSearchChecker $advancedSearchChecker;
     private Ontology $ontology;
-    private FeatureFlagChecker $featureFlagChecker;
 
     public function __construct(
         ElasticSearch $elasticSearch,
         AdvancedSearchChecker $advancedSearchChecker,
         Ontology $ontology,
-        FeatureFlagChecker $featureFlagChecker
     ) {
         $this->elasticSearch = $elasticSearch;
         $this->advancedSearchChecker = $advancedSearchChecker;
         $this->ontology = $ontology;
-        $this->featureFlagChecker = $featureFlagChecker;
     }
 
     public function findRelations(FindAllQuery $query): ResourceRelationCollection
     {
         $resourceRelationCollection = new ResourceRelationCollection();
-        if (
-            !$this->featureFlagChecker->isEnabled(ItemRelationsService::FEATURE_FLAG_ITEM_RELATION_ON_DELETE) ||
-            !$this->advancedSearchChecker->isEnabled()
-        ) {
+        if (!$this->advancedSearchChecker->isEnabled()) {
             common_Logger::w('Advanced search is not enabled, skipping item relations search');
             return $resourceRelationCollection;
         }

--- a/model/Resource/Service/ItemRelationsService.php
+++ b/model/Resource/Service/ItemRelationsService.php
@@ -25,7 +25,6 @@ namespace oat\taoAdvancedSearch\model\Resource\Service;
 use common_Logger;
 use InvalidArgumentException;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\resources\relation\FindAllQuery;
 use oat\tao\model\resources\relation\ResourceRelation;
 use oat\tao\model\resources\relation\ResourceRelationCollection;
@@ -38,29 +37,21 @@ class ItemRelationsService implements ResourceRelationServiceInterface
     private const TEST_INDEX = 'tests';
     private const TEST_RELATION = 'test';
     private const ITEM_URIS = 'item_uris';
-
-    public const FEATURE_FLAG_ITEM_RELATION_ON_DELETE = 'FEATURE_FLAG_ITEM_RELATION_ON_DELETE';
     private ElasticSearch $elasticSearch;
     private AdvancedSearchChecker $advancedSearchChecker;
-    private FeatureFlagChecker $featureFlagChecker;
 
     public function __construct(
         ElasticSearch $elasticSearch,
-        AdvancedSearchChecker $advancedSearchChecker,
-        FeatureFlagChecker $featureFlagChecker
+        AdvancedSearchChecker $advancedSearchChecker
     ) {
         $this->elasticSearch = $elasticSearch;
         $this->advancedSearchChecker = $advancedSearchChecker;
-        $this->featureFlagChecker = $featureFlagChecker;
     }
 
     public function findRelations(FindAllQuery $query): ResourceRelationCollection
     {
         $resourceRelationCollection = new ResourceRelationCollection();
-        if (
-            !$this->featureFlagChecker->isEnabled(self::FEATURE_FLAG_ITEM_RELATION_ON_DELETE) ||
-            !$this->advancedSearchChecker->isEnabled()
-        ) {
+        if (!$this->advancedSearchChecker->isEnabled()) {
             common_Logger::w('Advanced search is not enabled, skipping item relations search');
             return $resourceRelationCollection;
         }

--- a/model/Resource/ServiceProvider/ResourceServiceProvider.php
+++ b/model/Resource/ServiceProvider/ResourceServiceProvider.php
@@ -27,7 +27,6 @@ namespace oat\taoAdvancedSearch\model\Resource\ServiceProvider;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemClassRelationService;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemRelationsService;
@@ -57,7 +56,6 @@ class ResourceServiceProvider implements ContainerServiceProviderInterface
             ->args([
                 service(ElasticSearch::class),
                 service(AdvancedSearchChecker::class),
-                service(FeatureFlagChecker::class)
             ])
             ->public();
 
@@ -66,7 +64,6 @@ class ResourceServiceProvider implements ContainerServiceProviderInterface
                 service(ElasticSearch::class),
                 service(AdvancedSearchChecker::class),
                 service(Ontology::SERVICE_ID),
-                service(FeatureFlagChecker::class)
             ])
             ->public();
     }

--- a/tests/Unit/Resource/Service/ItemClassRelationServiceTest.php
+++ b/tests/Unit/Resource/Service/ItemClassRelationServiceTest.php
@@ -32,7 +32,6 @@ use oat\taoAdvancedSearch\model\SearchEngine\AggregationQuery;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use oat\taoAdvancedSearch\model\SearchEngine\Query;
 use PHPUnit\Framework\TestCase;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
 
 class ItemClassRelationServiceTest extends TestCase
 {
@@ -41,19 +40,16 @@ class ItemClassRelationServiceTest extends TestCase
         $this->elasticSearch = $this->createMock(ElasticSearch::class);
         $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
         $this->ontology = $this->createMock(Ontology::class);
-        $this->featureFlagChecker = $this->createMock(FeatureFlagChecker::class);
         $this->subject = new ItemClassRelationService(
             $this->elasticSearch,
             $this->advancedSearchChecker,
             $this->ontology,
-            $this->featureFlagChecker
         );
     }
 
     public function testFindRelations(): void
     {
         $this->advancedSearchChecker->method('isEnabled')->willReturn(true);
-        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
         $resource = $this->createMock(core_kernel_classes_Resource::class);
         $this->ontology
             ->expects(self::once())

--- a/tests/Unit/Resource/Service/ItemRelationsServiceTest.php
+++ b/tests/Unit/Resource/Service/ItemRelationsServiceTest.php
@@ -30,7 +30,6 @@ use oat\taoAdvancedSearch\model\Resource\Service\ItemRelationsService;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use oat\taoAdvancedSearch\model\SearchEngine\SearchResult;
 use PHPUnit\Framework\TestCase;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
 
 class ItemRelationsServiceTest extends TestCase
 {
@@ -38,11 +37,9 @@ class ItemRelationsServiceTest extends TestCase
     {
         $this->elasticSearch = $this->createMock(ElasticSearch::class);
         $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
-        $this->featureFlagChecker = $this->createMock(FeatureFlagChecker::class);
         $this->subject = new ItemRelationsService(
             $this->elasticSearch,
             $this->advancedSearchChecker,
-            $this->featureFlagChecker
         );
     }
 
@@ -50,7 +47,6 @@ class ItemRelationsServiceTest extends TestCase
     {
         $query = new FindAllQuery('itemSourceId', null, 'test');
         $this->advancedSearchChecker->method('isEnabled')->willReturn(true);
-        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
 
         $resultSearch = new SearchResult(
             [
@@ -75,7 +71,6 @@ class ItemRelationsServiceTest extends TestCase
     {
         $query = new FindAllQuery('sourceId', 'classId', 'test');
         $this->advancedSearchChecker->method('isEnabled')->willReturn(false);
-        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
         $result = $this->subject->findRelations($query);
         $this->assertInstanceOf(ResourceRelationCollection::class, $result);
         $this->assertEmpty($result->jsonSerialize());


### PR DESCRIPTION
This change removes FEATURE_FLAG_ITEM_RELATION_ON_DELETE and therefore item relation will be enabled by default whenever Elastic Search will be enabled. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logic for item relation searches by removing feature flag checks. Now, advanced search enablement solely determines availability.
* **Tests**
  * Updated unit tests to remove references to feature flag checks, aligning with the streamlined logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->