### PR TITLE
fix: improve loging and indexing

### DIFF
--- a/model/SearchEngine/Contract/IndexerInterface.php
+++ b/model/SearchEngine/Contract/IndexerInterface.php
@@ -24,6 +24,7 @@ namespace oat\taoAdvancedSearch\model\SearchEngine\Contract;
 
 use oat\tao\model\search\index\IndexDocument;
 use oat\tao\model\TaoOntology;
+use oat\taoAdvancedSearch\model\SearchEngine\IndexingResult;
 use oat\taoResultServer\models\classes\ResultService;
 use Iterator;
 
@@ -62,7 +63,7 @@ interface IndexerInterface
 
     public function getIndexNameByDocument(IndexDocument $document): string;
 
-    public function buildIndex(Iterator $documents): int;
+    public function buildIndex(Iterator $documents): IndexingResult;
 
     public function deleteDocument(string $id): bool;
 

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
@@ -174,25 +174,33 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
 
     public function index($documents = []): int
     {
-        $documents = $documents instanceof Iterator
+        $iterator = $documents instanceof Iterator
             ? $documents
             : new ArrayIterator($documents);
 
-        $cloneDocuments = clone $documents;
-        foreach ($cloneDocuments as $document) {
+        $validatedDocuments = [];
+
+        foreach ($iterator as $document) {
             if (!$document instanceof IndexDocument) {
                 throw new \InvalidArgumentException(
                     'Expected an instance of IndexDocument, got ' . get_class($document)
                 );
             }
+
             $indexName = $this->indexer->getIndexNameByDocument($document);
+
             if (!$this->isExistingIndex($indexName)) {
                 $this->createIndexes();
-                continue;
             }
+
+            $validatedDocuments[] = $document;
         }
 
-        return $this->indexer->buildIndex($documents);
+        if (empty($validatedDocuments)) {
+            return 0;
+        }
+
+        return $this->indexer->buildIndex(new ArrayIterator($validatedDocuments));
     }
 
     public function remove($resourceId): bool

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
@@ -191,6 +191,16 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
 
             if (!$this->isExistingIndex($indexName)) {
                 $this->createIndexes();
+
+                if (!$this->isExistingIndex($indexName)) {
+                    $this->logger->warning(
+                        sprintf(
+                            'Index "%s" still does not exist after creation attempt, skipping document',
+                            $indexName
+                        )
+                    );
+                    continue;
+                }
             }
 
             $validatedDocuments[] = $document;

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
@@ -34,6 +34,7 @@ use oat\taoAdvancedSearch\model\SearchEngine\AggregationQuery;
 use oat\taoAdvancedSearch\model\SearchEngine\AggregationResult;
 use oat\taoAdvancedSearch\model\SearchEngine\Contract\IndexerInterface;
 use oat\taoAdvancedSearch\model\SearchEngine\Contract\SearchInterface;
+use oat\taoAdvancedSearch\model\SearchEngine\IndexingResult;
 use oat\taoAdvancedSearch\model\SearchEngine\Normalizer\SearchResultNormalizer;
 use oat\taoAdvancedSearch\model\SearchEngine\Query;
 use oat\taoAdvancedSearch\model\SearchEngine\SearchResult;
@@ -62,6 +63,9 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
 
     /** @var SearchResultNormalizer */
     private $searchResultNormalizer;
+
+    /** @var IndexingResult|null */
+    private $lastIndexingResult;
 
     public function __construct(
         Client $client,
@@ -174,11 +178,14 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
 
     public function index($documents = []): int
     {
+        $this->lastIndexingResult = null;
+
         $iterator = $documents instanceof Iterator
             ? $documents
             : new ArrayIterator($documents);
 
         $validatedDocuments = [];
+        $skippedError = null;
 
         foreach ($iterator as $document) {
             if (!$document instanceof IndexDocument) {
@@ -194,12 +201,8 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
                 $this->createIndexes();
 
                 if (!$this->isExistingIndex($indexName)) {
-                    $this->logger->warning(
-                        sprintf(
-                            'Index "%s" still does not exist after creation attempt, skipping document',
-                            $indexName
-                        )
-                    );
+                    $skippedError = sprintf('Index "%s" does not exist after creation attempt', $indexName);
+                    $this->logger->warning($skippedError . ', skipping document');
                     continue;
                 }
             }
@@ -208,10 +211,18 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
         }
 
         if (empty($validatedDocuments)) {
+            $this->lastIndexingResult = new IndexingResult(0, $skippedError);
             return 0;
         }
 
-        return $this->indexer->buildIndex(new ArrayIterator($validatedDocuments));
+        $this->lastIndexingResult = $this->indexer->buildIndex(new ArrayIterator($validatedDocuments));
+
+        return $this->lastIndexingResult->getTotalIndexed();
+    }
+
+    public function getLastIndexingResult(): ?IndexingResult
+    {
+        return $this->lastIndexingResult;
     }
 
     public function remove($resourceId): bool

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearch.php
@@ -182,8 +182,9 @@ class ElasticSearch implements SearchInterface, TaoSearchInterface
 
         foreach ($iterator as $document) {
             if (!$document instanceof IndexDocument) {
+                $actualType = is_object($document) ? get_class($document) : gettype($document);
                 throw new \InvalidArgumentException(
-                    'Expected an instance of IndexDocument, got ' . get_class($document)
+                    'Expected an instance of IndexDocument, got ' . $actualType
                 );
             }
 

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
@@ -122,7 +122,7 @@ class ElasticSearchIndexer implements IndexerInterface
             if ($blockSize === self::INDEXING_BLOCK_SIZE) {
                 $this->logBatchFlush($this->logger, __METHOD__, $params);
 
-                $response = $this->client->bulk($params);
+                $response = $this->client->bulk($params)->asArray();
                 $this->logErrorsFromResponse($this->logger, $document, $response);
 
                 $count += $blockSize;
@@ -134,7 +134,7 @@ class ElasticSearchIndexer implements IndexerInterface
         if ($blockSize > 0) {
             $this->logBatchFlush($this->logger, __METHOD__, $params);
 
-            $response = $this->client->bulk($params);
+            $response = $this->client->bulk($params)->asArray();
             $this->logErrorsFromResponse($this->logger, null, $response);
 
             $count += $blockSize;

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
@@ -25,6 +25,7 @@ namespace oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch;
 use oat\tao\model\search\index\IndexDocument;
 use Elastic\Elasticsearch\Client;
 use oat\taoAdvancedSearch\model\SearchEngine\Contract\IndexerInterface;
+use oat\taoAdvancedSearch\model\SearchEngine\IndexingResult;
 use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use Psr\Log\LoggerInterface;
 use Exception;
@@ -73,7 +74,7 @@ class ElasticSearchIndexer implements IndexerInterface
         return IndexerInterface::UNCLASSIFIEDS_DOCUMENTS_INDEX;
     }
 
-    public function buildIndex(Iterator $documents): int
+    public function buildIndex(Iterator $documents): IndexingResult
     {
         $visited = 0;
         $skipped = 0;
@@ -81,6 +82,7 @@ class ElasticSearchIndexer implements IndexerInterface
         $count = 0;
         $blockSize = 0;
         $params = [];
+        $errorMessage = null;
 
         while ($documents->valid()) {
             /** @var IndexDocument $document */
@@ -91,7 +93,9 @@ class ElasticSearchIndexer implements IndexerInterface
                 $indexName = $this->getIndexNameByDocument($document);
             } catch (Exception $e) {
                 $this->logIndexFailure($this->logger, $e, __METHOD__);
+                $errorMessage = $e->getMessage();
                 $exceptions++;
+                $documents->next();
 
                 continue;
             }
@@ -125,9 +129,10 @@ class ElasticSearchIndexer implements IndexerInterface
                 $response = $this->client->bulk($params);
                 $response = is_array($response) ? $response : $response->asArray();
 
-                $this->logErrorsFromResponse($this->logger, $document, $response);
+                $batchError = $this->logErrorsFromResponse($this->logger, $document, $response);
 
-                if (!empty($response['errors'])) {
+                if ($batchError !== null) {
+                    $errorMessage = $batchError;
                     $exceptions++;
                 } else {
                     $count += $blockSize;
@@ -144,9 +149,10 @@ class ElasticSearchIndexer implements IndexerInterface
             $response = $this->client->bulk($params);
             $response = is_array($response) ? $response : $response->asArray();
 
-            $this->logErrorsFromResponse($this->logger, null, $response);
+            $batchError = $this->logErrorsFromResponse($this->logger, null, $response);
 
-            if (!empty($response['errors'])) {
+            if ($batchError !== null) {
+                $errorMessage = $batchError;
                 $exceptions++;
             } else {
                 $count += $blockSize;
@@ -155,7 +161,7 @@ class ElasticSearchIndexer implements IndexerInterface
 
         $this->logCompletion($this->logger, $count, $visited, $skipped, $exceptions);
 
-        return $count;
+        return new IndexingResult($count, $errorMessage);
     }
 
     public function deleteDocument(string $id): bool

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
@@ -127,7 +127,12 @@ class ElasticSearchIndexer implements IndexerInterface
 
                 $this->logErrorsFromResponse($this->logger, $document, $response);
 
-                $count += $blockSize;
+                if (!empty($response['errors'])) {
+                    $exceptions++;
+                } else {
+                    $count += $blockSize;
+                }
+
                 $blockSize = 0;
                 $params = [];
             }
@@ -141,7 +146,11 @@ class ElasticSearchIndexer implements IndexerInterface
 
             $this->logErrorsFromResponse($this->logger, null, $response);
 
-            $count += $blockSize;
+            if (!empty($response['errors'])) {
+                $exceptions++;
+            } else {
+                $count += $blockSize;
+            }
         }
 
         $this->logCompletion($this->logger, $count, $visited, $skipped, $exceptions);

--- a/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
+++ b/model/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexer.php
@@ -122,7 +122,9 @@ class ElasticSearchIndexer implements IndexerInterface
             if ($blockSize === self::INDEXING_BLOCK_SIZE) {
                 $this->logBatchFlush($this->logger, __METHOD__, $params);
 
-                $response = $this->client->bulk($params)->asArray();
+                $response = $this->client->bulk($params);
+                $response = is_array($response) ? $response : $response->asArray();
+
                 $this->logErrorsFromResponse($this->logger, $document, $response);
 
                 $count += $blockSize;
@@ -134,7 +136,9 @@ class ElasticSearchIndexer implements IndexerInterface
         if ($blockSize > 0) {
             $this->logBatchFlush($this->logger, __METHOD__, $params);
 
-            $response = $this->client->bulk($params)->asArray();
+            $response = $this->client->bulk($params);
+            $response = is_array($response) ? $response : $response->asArray();
+
             $this->logErrorsFromResponse($this->logger, null, $response);
 
             $count += $blockSize;

--- a/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
+++ b/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
@@ -91,6 +91,23 @@ trait LogIndexOperationsTrait
 
     private function logErrorsFromResponse(LoggerInterface $logger, ?IndexDocument $document, $clientResponse): void
     {
+        if (!is_array($clientResponse)) {
+            // Try best-effort normalization for unexpected response types
+            if (is_object($clientResponse) && method_exists($clientResponse, 'asArray')) {
+                $clientResponse = $clientResponse->asArray();
+            } else {
+                $logger->warning(
+                    ($document ? sprintf('[documentId: "%s"] ', $document->getId()) : '') .
+                    sprintf(
+                        'Unexpected non-array client response of type %s',
+                        is_object($clientResponse) ? get_class($clientResponse) : gettype($clientResponse)
+                    )
+                );
+
+                return;
+            }
+        }
+
         if ($clientResponse['errors'] ?? false) {
             $logger->warning(
                 ($document ? sprintf('[documentId: "%s"] ', $document->getId()) : '') .
@@ -99,6 +116,21 @@ trait LogIndexOperationsTrait
                     json_encode($clientResponse)
                 )
             );
+
+            if (isset($clientResponse['items']) && is_array($clientResponse['items'])) {
+                foreach ($clientResponse['items'] as $item) {
+                    $action = key($item);
+                    $result = current($item);
+
+                    if (!empty($result['error'])) {
+                        $logger->warning(sprintf(
+                            'Bulk item error (action=%s): %s',
+                            $action,
+                            json_encode($result['error'])
+                        ));
+                    }
+                }
+            }
         }
     }
 

--- a/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
+++ b/model/SearchEngine/Driver/Elasticsearch/LogIndexOperationsTrait.php
@@ -89,22 +89,21 @@ trait LogIndexOperationsTrait
         }
     }
 
-    private function logErrorsFromResponse(LoggerInterface $logger, ?IndexDocument $document, $clientResponse): void
+    private function logErrorsFromResponse(LoggerInterface $logger, ?IndexDocument $document, $clientResponse): ?string
     {
         if (!is_array($clientResponse)) {
-            // Try best-effort normalization for unexpected response types
             if (is_object($clientResponse) && method_exists($clientResponse, 'asArray')) {
                 $clientResponse = $clientResponse->asArray();
             } else {
+                $errorMessage = sprintf(
+                    'Unexpected non-array client response of type %s',
+                    is_object($clientResponse) ? get_class($clientResponse) : gettype($clientResponse)
+                );
                 $logger->warning(
-                    ($document ? sprintf('[documentId: "%s"] ', $document->getId()) : '') .
-                    sprintf(
-                        'Unexpected non-array client response of type %s',
-                        is_object($clientResponse) ? get_class($clientResponse) : gettype($clientResponse)
-                    )
+                    ($document ? sprintf('[documentId: "%s"] ', $document->getId()) : '') . $errorMessage
                 );
 
-                return;
+                return $errorMessage;
             }
         }
 
@@ -128,10 +127,27 @@ trait LogIndexOperationsTrait
                             $action,
                             json_encode($result['error'])
                         ));
+
+                        return $this->extractErrorReason($result['error']);
                     }
                 }
             }
+
+            return 'Unknown indexing error';
         }
+
+        return null;
+    }
+
+    private function extractErrorReason(array $error): string
+    {
+        $reason = $error['reason'] ?? 'Unknown error';
+
+        if (isset($error['caused_by']['reason'])) {
+            $reason .= ': ' . $error['caused_by']['reason'];
+        }
+
+        return $reason;
     }
 
     private function logUnclassifiedDocument(

--- a/model/SearchEngine/IndexingResult.php
+++ b/model/SearchEngine/IndexingResult.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\model\SearchEngine;
+
+class IndexingResult
+{
+    private int $totalIndexed;
+    private ?string $errorMessage;
+
+    public function __construct(int $totalIndexed, ?string $errorMessage = null)
+    {
+        $this->totalIndexed = $totalIndexed;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function getTotalIndexed(): int
+    {
+        return $this->totalIndexed;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+    public function hasError(): bool
+    {
+        return $this->errorMessage !== null;
+    }
+}

--- a/tests/Unit/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexerTest.php
+++ b/tests/Unit/SearchEngine/Driver/Elasticsearch/ElasticSearchIndexerTest.php
@@ -150,9 +150,11 @@ class ElasticSearchIndexerTest extends TestCase
             ])
             ->willReturn(['bulk_response']);
 
-        $count = $this->sut->buildIndex($iterator);
+        $result = $this->sut->buildIndex($iterator);
 
-        $this->assertSame(1, $count);
+        $this->assertSame(1, $result->getTotalIndexed());
+        $this->assertNull($result->getErrorMessage());
+        $this->assertFalse($result->hasError());
     }
 
     private function createIterator(array $items = []): MockObject


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-2264

```
[https://...260313110339daa191a2] failed with MSG: Trying to clone an uncloneable object of class oat\tao\model\search\index\IndexIterator. [Error] Trace: #0 /.../tao/models/classes/search/SearchProxy.php(147): oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch->index(Object(oat\tao\model\search\index\IndexIterator))

```
What was fixed:

* fixed the issue with dublicating document object
* Improve logs
* failed task if index was failed during bulk indexing

Expected error message inside a task:
```{"type":"info","message":"Running task https:\/\/backoffice.ngs.test\/ontologies\/tao.rdf#i69cfb632a4266202604031444340111fa32","data":null,"children":[{"type":"error","message":"Expecting document(s) to be indexed (got zero) for ID(s) \"https:\/\/backoffice.ngs.test\/ontologies\/tao.rdf#i69cfb6329d6052026040314443450cb6d2e\". Reason: [1:2045] failed to parse: Limit of total fields [1000] has been exceeded while adding new fields [2]: Limit of total fields [1000] has been exceeded while adding new fields [2]","data":null,"children":[]}]}```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexing now returns and exposes a richer indexing result (total indexed + optional error) via a public accessor.

* **Bug Fixes**
  * More consistent normalization and reporting of unexpected bulk responses; improved extraction of per-item error reasons.
  * Stronger input validation: non-document inputs are rejected; documents without a resolvable index are skipped.

* **Improvements**
  * Two-phase validation and selective batching for predictable processing and clearer outcome reporting.

* **Tests**
  * Unit tests updated to assert the richer indexing result shape and error state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->