### PR TITLE
feat: AUT-4526 add orchestrated test-to-delivery relation flow

### DIFF
--- a/.notes/pr-description/AUT-4526.md
+++ b/.notes/pr-description/AUT-4526.md
@@ -1,0 +1,9 @@
+## Summary
+- Add `TestDeliveryRelationService` to resolve test -> delivery relations using Elasticsearch first (`deliveries` index, `test_uri` field) and fallback deterministically to RDF relation type `delivery_rdf` when advanced search is disabled or Elasticsearch fails.
+- Register a single orchestrator relation service under type `delivery` and add migration `Version202604081043571488_taoAdvancedSearch` to apply registration on existing installs.
+- Add focused unit coverage for ES path, disabled fallback path, exception fallback path, and deterministic no-fallback behavior for empty ES results.
+
+## Validation
+- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php`
+- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemRelationsServiceTest.php`
+- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemClassRelationServiceTest.php`

--- a/.notes/pr-description/AUT-4526.md
+++ b/.notes/pr-description/AUT-4526.md
@@ -1,9 +1,0 @@
-## Summary
-- Add `TestDeliveryRelationService` to resolve test -> delivery relations using Elasticsearch first (`deliveries` index, `test_uri` field) and fallback deterministically to RDF relation type `delivery_rdf` when advanced search is disabled or Elasticsearch fails.
-- Register a single orchestrator relation service under type `delivery` and add migration `Version202604081043571488_taoAdvancedSearch` to apply registration on existing installs.
-- Add focused unit coverage for ES path, disabled fallback path, exception fallback path, and deterministic no-fallback behavior for empty ES results.
-
-## Validation
-- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php`
-- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemRelationsServiceTest.php`
-- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemClassRelationServiceTest.php`

--- a/migrations/Version202604081043571488_taoAdvancedSearch.php
+++ b/migrations/Version202604081043571488_taoAdvancedSearch.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\resources\relation\service\ResourceRelationServiceProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoAdvancedSearch\model\Resource\Service\TestDeliveryRelationService;
+use oat\taoAdvancedSearch\scripts\install\RegisterItemRelationsService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202604081043571488_taoAdvancedSearch extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register test->delivery relation orchestrator service for advanced search';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->runAction(new RegisterItemRelationsService());
+    }
+
+    public function down(Schema $schema): void
+    {
+        $resourceRelationService = $this->getServiceManager()->get(ResourceRelationServiceProxy::SERVICE_ID);
+        $resourceRelationService->removeService('delivery', TestDeliveryRelationService::class);
+        $this->getServiceManager()->register(ResourceRelationServiceProxy::SERVICE_ID, $resourceRelationService);
+    }
+}

--- a/model/Resource/Service/TestDeliveryRelationService.php
+++ b/model/Resource/Service/TestDeliveryRelationService.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\model\Resource\Service;
+
+use common_Logger;
+use InvalidArgumentException;
+use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\resources\relation\FindAllQuery;
+use oat\tao\model\resources\relation\ResourceRelation;
+use oat\tao\model\resources\relation\ResourceRelationCollection;
+use oat\tao\model\resources\relation\service\ResourceRelationServiceInterface;
+use oat\tao\model\resources\relation\service\ResourceRelationServiceProxy;
+use oat\tao\model\search\ResultSet;
+use oat\taoAdvancedSearch\model\SearchEngine\Contract\IndexerInterface;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
+use Throwable;
+
+class TestDeliveryRelationService implements ResourceRelationServiceInterface
+{
+    private const DELIVERY_RELATION = 'delivery';
+    private const FALLBACK_RELATION_TYPE = 'delivery_rdf';
+    private const TEST_URI_FIELD = 'test_uri';
+
+    private ElasticSearch $elasticSearch;
+    private AdvancedSearchChecker $advancedSearchChecker;
+    private ResourceRelationServiceProxy $resourceRelationServiceProxy;
+
+    public function __construct(
+        ElasticSearch $elasticSearch,
+        AdvancedSearchChecker $advancedSearchChecker,
+        ResourceRelationServiceProxy $resourceRelationServiceProxy
+    ) {
+        $this->elasticSearch = $elasticSearch;
+        $this->advancedSearchChecker = $advancedSearchChecker;
+        $this->resourceRelationServiceProxy = $resourceRelationServiceProxy;
+    }
+
+    public function findRelations(FindAllQuery $query): ResourceRelationCollection
+    {
+        if (!$query->getSourceId()) {
+            throw new InvalidArgumentException('Query must have sourceId to resolve deliveries');
+        }
+
+        if (!$this->advancedSearchChecker->isEnabled()) {
+            return $this->findRdfRelations($query);
+        }
+
+        try {
+            return $this->findElasticsearchRelations($query->getSourceId());
+        } catch (Throwable $exception) {
+            common_Logger::w(
+                sprintf(
+                    'Unable to load test->delivery relations from Elasticsearch, fallback to RDF. Error: %s',
+                    $exception->getMessage()
+                )
+            );
+
+            return $this->findRdfRelations($query);
+        }
+    }
+
+    private function findElasticsearchRelations(string $testUri): ResourceRelationCollection
+    {
+        $relations = [];
+
+        foreach ($this->searchDeliveriesByTestUri($testUri) as $delivery) {
+            $labels = $delivery['label'] ?? [];
+            $relations[] = new ResourceRelation(
+                self::DELIVERY_RELATION,
+                $delivery['id'],
+                reset($labels)
+            );
+        }
+
+        return new ResourceRelationCollection(...$relations);
+    }
+
+    private function searchDeliveriesByTestUri(string $testUri): ResultSet
+    {
+        return $this->elasticSearch->query(
+            sprintf('%s:%s', self::TEST_URI_FIELD, $testUri),
+            IndexerInterface::DELIVERIES_INDEX,
+            0,
+            100,
+            'label.raw'
+        );
+    }
+
+    private function findRdfRelations(FindAllQuery $query): ResourceRelationCollection
+    {
+        return $this->resourceRelationServiceProxy->findRelations(
+            new FindAllQuery(
+                $query->getSourceId(),
+                $query->getClassId(),
+                self::FALLBACK_RELATION_TYPE
+            )
+        );
+    }
+}

--- a/model/Resource/Service/TestDeliveryRelationService.php
+++ b/model/Resource/Service/TestDeliveryRelationService.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
  * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
  */

--- a/model/Resource/ServiceProvider/ResourceServiceProvider.php
+++ b/model/Resource/ServiceProvider/ResourceServiceProvider.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2022-2025 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022-2026 (original work) Open Assessment Technologies SA;
  *
  * @author Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
  */

--- a/model/Resource/ServiceProvider/ResourceServiceProvider.php
+++ b/model/Resource/ServiceProvider/ResourceServiceProvider.php
@@ -27,10 +27,12 @@ namespace oat\taoAdvancedSearch\model\Resource\ServiceProvider;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\resources\relation\service\ResourceRelationServiceProxy;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemClassRelationService;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemRelationsService;
 use oat\taoAdvancedSearch\model\Resource\Service\ResourceIndexer;
+use oat\taoAdvancedSearch\model\Resource\Service\TestDeliveryRelationService;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -64,6 +66,14 @@ class ResourceServiceProvider implements ContainerServiceProviderInterface
                 service(ElasticSearch::class),
                 service(AdvancedSearchChecker::class),
                 service(Ontology::SERVICE_ID),
+            ])
+            ->public();
+
+        $services->set(TestDeliveryRelationService::class)
+            ->args([
+                service(ElasticSearch::class),
+                service(AdvancedSearchChecker::class),
+                service(ResourceRelationServiceProxy::SERVICE_ID),
             ])
             ->public();
     }

--- a/scripts/install/RegisterItemRelationsService.php
+++ b/scripts/install/RegisterItemRelationsService.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2025-2026 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/scripts/install/RegisterItemRelationsService.php
+++ b/scripts/install/RegisterItemRelationsService.php
@@ -26,6 +26,7 @@ use oat\oatbox\extension\InstallAction;
 use oat\tao\model\resources\relation\service\ResourceRelationServiceProxy;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemClassRelationService;
 use oat\taoAdvancedSearch\model\Resource\Service\ItemRelationsService;
+use oat\taoAdvancedSearch\model\Resource\Service\TestDeliveryRelationService;
 
 class RegisterItemRelationsService extends InstallAction
 {
@@ -34,6 +35,7 @@ class RegisterItemRelationsService extends InstallAction
         $resourceRelationServiceProxy = $this->getServiceManager()->get(ResourceRelationServiceProxy::SERVICE_ID);
         $resourceRelationServiceProxy->addService('test', ItemRelationsService::class);
         $resourceRelationServiceProxy->addService('itemClass', ItemClassRelationService::class);
+        $resourceRelationServiceProxy->addService('delivery', TestDeliveryRelationService::class);
         $this->getServiceManager()->register(
             ResourceRelationServiceProxy::SERVICE_ID,
             $resourceRelationServiceProxy

--- a/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php
+++ b/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\tests\Unit\Resource\Service;
+
+use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\resources\relation\FindAllQuery;
+use oat\tao\model\resources\relation\ResourceRelation;
+use oat\tao\model\resources\relation\ResourceRelationCollection;
+use oat\tao\model\resources\relation\service\ResourceRelationServiceProxy;
+use oat\taoAdvancedSearch\model\Resource\Service\TestDeliveryRelationService;
+use oat\taoAdvancedSearch\model\SearchEngine\Contract\IndexerInterface;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
+use oat\taoAdvancedSearch\model\SearchEngine\SearchResult;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class TestDeliveryRelationServiceTest extends TestCase
+{
+    private ElasticSearch $elasticSearch;
+    private AdvancedSearchChecker $advancedSearchChecker;
+    private ResourceRelationServiceProxy $resourceRelationServiceProxy;
+    private TestDeliveryRelationService $subject;
+
+    protected function setUp(): void
+    {
+        $this->elasticSearch = $this->createMock(ElasticSearch::class);
+        $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
+        $this->resourceRelationServiceProxy = $this->createMock(ResourceRelationServiceProxy::class);
+
+        $this->subject = new TestDeliveryRelationService(
+            $this->elasticSearch,
+            $this->advancedSearchChecker,
+            $this->resourceRelationServiceProxy
+        );
+    }
+
+    public function testFindRelationsUsesElasticsearchWhenEnabled(): void
+    {
+        $query = new FindAllQuery('testUri', null, 'delivery');
+
+        $this->advancedSearchChecker->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->elasticSearch->expects(self::once())
+            ->method('query')
+            ->with('test_uri:testUri', IndexerInterface::DELIVERIES_INDEX, 0, 100, 'label.raw')
+            ->willReturn(
+                new SearchResult(
+                    [
+                        [
+                            'id' => 'deliveryUri',
+                            'label' => ['Delivery Label'],
+                        ],
+                    ],
+                    1
+                )
+            );
+
+        $this->resourceRelationServiceProxy->expects(self::never())
+            ->method('findRelations');
+
+        $result = $this->subject->findRelations($query);
+        $serialized = $result->jsonSerialize();
+
+        self::assertCount(1, $serialized);
+        /** @var ResourceRelation $first */
+        $first = reset($serialized);
+        self::assertSame('delivery', $first->getType());
+        self::assertSame('deliveryUri', $first->getId());
+        self::assertSame('Delivery Label', $first->getLabel());
+    }
+
+    public function testFindRelationsUsesRdfFallbackWhenAdvancedSearchDisabled(): void
+    {
+        $query = new FindAllQuery('testUri', null, 'delivery');
+        $fallbackResult = new ResourceRelationCollection();
+
+        $this->advancedSearchChecker->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(false);
+
+        $this->elasticSearch->expects(self::never())
+            ->method('query');
+
+        $this->resourceRelationServiceProxy->expects(self::once())
+            ->method('findRelations')
+            ->with(self::callback(static function (FindAllQuery $fallbackQuery): bool {
+                return $fallbackQuery->getSourceId() === 'testUri'
+                    && $fallbackQuery->getType() === 'delivery_rdf';
+            }))
+            ->willReturn($fallbackResult);
+
+        self::assertSame($fallbackResult, $this->subject->findRelations($query));
+    }
+
+    public function testFindRelationsUsesRdfFallbackWhenElasticsearchFails(): void
+    {
+        $query = new FindAllQuery('testUri', null, 'delivery');
+        $fallbackResult = new ResourceRelationCollection();
+
+        $this->advancedSearchChecker->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->elasticSearch->expects(self::once())
+            ->method('query')
+            ->willThrowException(new RuntimeException('Elasticsearch unavailable'));
+
+        $this->resourceRelationServiceProxy->expects(self::once())
+            ->method('findRelations')
+            ->with(self::callback(static function (FindAllQuery $fallbackQuery): bool {
+                return $fallbackQuery->getSourceId() === 'testUri'
+                    && $fallbackQuery->getType() === 'delivery_rdf';
+            }))
+            ->willReturn($fallbackResult);
+
+        self::assertSame($fallbackResult, $this->subject->findRelations($query));
+    }
+
+    public function testFindRelationsDoesNotUseFallbackWhenElasticsearchReturnsEmptyResult(): void
+    {
+        $query = new FindAllQuery('testUri', null, 'delivery');
+
+        $this->advancedSearchChecker->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->elasticSearch->expects(self::once())
+            ->method('query')
+            ->willReturn(new SearchResult([], 0));
+
+        $this->resourceRelationServiceProxy->expects(self::never())
+            ->method('findRelations');
+
+        self::assertCount(0, $this->subject->findRelations($query)->jsonSerialize());
+    }
+}

--- a/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php
+++ b/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
  * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
  */


### PR DESCRIPTION
## Summary
- Add `TestDeliveryRelationService` to resolve test -> delivery relations using Elasticsearch first (`deliveries` index, `test_uri` field) and fallback deterministically to RDF relation type `delivery_rdf` when advanced search is disabled or Elasticsearch fails.
- Register a single orchestrator relation service under type `delivery` and add migration `Version202604081043571488_taoAdvancedSearch` to apply registration on existing installs.
- Add focused unit coverage for ES path, disabled fallback path, exception fallback path, and deterministic no-fallback behavior for empty ES results.

## Validation
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/TestDeliveryRelationServiceTest.php`
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemRelationsServiceTest.php`
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoAdvancedSearch/tests/Unit/Resource/Service/ItemClassRelationServiceTest.php`