### PR TITLE
feat: Elasticsearch item comment persistence adapter (NYSED-13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "oat-sa/extension-tao-outcome": ">=13.0.0",
     "oat-sa/extension-tao-test": ">=16.4.0",
     "oat-sa/extension-tao-mediamanager": ">=12.32.1",
+    "oat-sa/extension-tao-item": ">=12.0.0",
     "elasticsearch/elasticsearch": "^8.0"
   },
   "require-dev": {

--- a/config/item-comments.conf.php
+++ b/config/item-comments.conf.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+return [
+    'index' => 'item-comments',
+    'body' => [
+        'mappings' => [
+            'properties' => [
+                'id' => [
+                    'type' => 'keyword',
+                    'ignore_above' => 256,
+                ],
+                'itemUri' => [
+                    'type' => 'keyword',
+                    'ignore_above' => 512,
+                ],
+                'authorId' => [
+                    'type' => 'keyword',
+                    'ignore_above' => 512,
+                ],
+                'authorLabel' => [
+                    'type' => 'text',
+                    'fields' => [
+                        'raw' => [
+                            'type' => 'keyword',
+                            'ignore_above' => 256,
+                        ],
+                    ],
+                ],
+                'body' => [
+                    'type' => 'text',
+                ],
+                'createdAt' => [
+                    'type' => 'date',
+                ],
+                'status' => [
+                    'type' => 'keyword',
+                    'ignore_above' => 64,
+                ],
+            ],
+        ],
+        'settings' => [
+            'index' => [
+                'number_of_shards' => '1',
+                'number_of_replicas' => '1',
+            ],
+        ],
+    ],
+];

--- a/manifest.php
+++ b/manifest.php
@@ -24,6 +24,7 @@ use oat\taoAdvancedSearch\model\Resource\ServiceProvider\ResourceServiceProvider
 use oat\taoAdvancedSearch\model\SearchEngine\ServiceProvider\SearchEngineProvider;
 use oat\taoAdvancedSearch\model\Test\ServiceProvider\TestServiceProvider;
 use oat\taoAdvancedSearch\scripts\install\RegisterEvents;
+use oat\taoAdvancedSearch\scripts\install\RegisterItemCommentElasticsearchAdapter;
 use oat\taoAdvancedSearch\scripts\install\RegisterItemRelationsService;
 use oat\taoAdvancedSearch\scripts\install\RegisterServices;
 use oat\taoAdvancedSearch\scripts\install\RegisterTaskQueueServices;
@@ -47,6 +48,7 @@ return [
             RegisterEvents::class,
             RegisterTaskQueueServices::class,
             RegisterItemRelationsService::class,
+            RegisterItemCommentElasticsearchAdapter::class,
         ],
         'rdf' => []
     ],

--- a/migrations/Version202608031750001488_taoAdvancedSearch.php
+++ b/migrations/Version202608031750001488_taoAdvancedSearch.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoAdvancedSearch\scripts\install\RegisterItemCommentElasticsearchAdapter;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202608031750001488_taoAdvancedSearch extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace Item Comment persistence adapter with Elasticsearch (NYSED-19)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $script = new RegisterItemCommentElasticsearchAdapter();
+        $script->setServiceLocator($this->getServiceLocator());
+        $script([]);
+
+        $this->addReport(
+            Report::createSuccess('Item Comment persistence adapter switched to Elasticsearch')
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty.
+    }
+}

--- a/migrations/Version202608041200001488_taoAdvancedSearch.php
+++ b/migrations/Version202608041200001488_taoAdvancedSearch.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoAdvancedSearch\scripts\install\RegisterItemCommentElasticsearchAdapter;
+use Throwable;
+
+/**
+ * Ensures item-comments Elasticsearch index exists and switches comment persistence to ES.
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202608041200001488_taoAdvancedSearch extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create item-comments ES index and adjust Item Comment business logic to Elasticsearch adapter (NYSED-19)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        try {
+            $script = new RegisterItemCommentElasticsearchAdapter();
+            $script->setServiceLocator($this->getServiceLocator());
+            $report = $script([]);
+
+            if ($report instanceof Report) {
+                $this->addReport($report);
+            } else {
+                $this->addReport(
+                    Report::createSuccess('Item comments persistence switched to Elasticsearch')
+                );
+            }
+        } catch (Throwable $exception) {
+            $this->addReport(
+                Report::createError(
+                    sprintf('Failed adjusting item comments to Elasticsearch: %s', $exception->getMessage())
+                )
+            );
+            throw $exception;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty: index and ES adapter remain for forward compatibility.
+    }
+}

--- a/model/Comment/ElasticsearchItemCommentAdapter.php
+++ b/model/Comment/ElasticsearchItemCommentAdapter.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\model\Comment;
+
+use Elastic\Elasticsearch\Client;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
+use oat\taoItems\model\Comment\ItemComment;
+use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
+use RuntimeException;
+
+class ElasticsearchItemCommentAdapter extends ConfigurableService implements ItemCommentPersistenceInterface
+{
+    public const SERVICE_ID = 'taoAdvancedSearch/ElasticsearchItemCommentAdapter';
+    public const INDEX_NAME = 'item-comments';
+
+    public function create(ItemComment $comment): ItemComment
+    {
+        $document = $comment->toArray();
+        $params = [
+            'index' => $this->getIndexName(),
+            'id' => $comment->getId(),
+            'body' => $document,
+            'refresh' => true,
+        ];
+
+        $response = $this->getClient()->index($params)->asArray();
+        if (($response['result'] ?? null) !== 'created' && ($response['result'] ?? null) !== 'updated') {
+            throw new RuntimeException('Failed to index item comment in Elasticsearch');
+        }
+
+        return $comment;
+    }
+
+    public function findByItemUri(string $itemUri): array
+    {
+        $params = [
+            'index' => $this->getIndexName(),
+            'body' => [
+                'size' => 1000,
+                'sort' => [
+                    ['createdAt' => ['order' => 'asc']],
+                ],
+                'query' => [
+                    'term' => [
+                        'itemUri.keyword' => $itemUri,
+                    ],
+                ],
+            ],
+        ];
+
+        try {
+            $response = $this->getClient()->search($params)->asArray();
+        } catch (\Throwable $exception) {
+            // Fallback for indices where itemUri is already keyword-mapped.
+            $params['body']['query'] = [
+                'term' => [
+                    'itemUri' => $itemUri,
+                ],
+            ];
+            $response = $this->getClient()->search($params)->asArray();
+        }
+
+        $comments = [];
+        foreach ($response['hits']['hits'] ?? [] as $hit) {
+            $source = $hit['_source'] ?? [];
+            $comments[] = new ItemComment(
+                (string) ($source['id'] ?? $hit['_id'] ?? ''),
+                (string) ($source['itemUri'] ?? ''),
+                (string) ($source['authorId'] ?? ''),
+                (string) ($source['authorLabel'] ?? ''),
+                (string) ($source['body'] ?? ''),
+                (string) ($source['createdAt'] ?? ''),
+                (string) ($source['status'] ?? ItemComment::STATUS_ACTIVE)
+            );
+        }
+
+        return $comments;
+    }
+
+    public function countByItemUri(string $itemUri): int
+    {
+        $params = [
+            'index' => $this->getIndexName(),
+            'body' => [
+                'query' => [
+                    'term' => [
+                        'itemUri.keyword' => $itemUri,
+                    ],
+                ],
+            ],
+        ];
+
+        try {
+            $response = $this->getClient()->count($params)->asArray();
+        } catch (\Throwable $exception) {
+            $params['body']['query'] = [
+                'term' => [
+                    'itemUri' => $itemUri,
+                ],
+            ];
+            $response = $this->getClient()->count($params)->asArray();
+        }
+
+        return (int) ($response['count'] ?? 0);
+    }
+
+    private function getIndexName(): string
+    {
+        return $this->getIndexPrefixer()->prefix(self::INDEX_NAME);
+    }
+
+    private function getClient(): Client
+    {
+        return $this->getServiceLocator()->get(Client::class);
+    }
+
+    private function getIndexPrefixer(): IndexPrefixer
+    {
+        return $this->getServiceLocator()->get(IndexPrefixer::class);
+    }
+}

--- a/model/Comment/ElasticsearchItemCommentAdapter.php
+++ b/model/Comment/ElasticsearchItemCommentAdapter.php
@@ -23,11 +23,15 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\model\Comment;
 
 use Elastic\Elasticsearch\Client;
+use oat\generis\model\DependencyInjection\ServiceOptions;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchClientFactory;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchConfig;
 use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use oat\taoItems\model\Comment\ItemComment;
 use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
 use RuntimeException;
+use Throwable;
 
 class ElasticsearchItemCommentAdapter extends ConfigurableService implements ItemCommentPersistenceInterface
 {
@@ -36,11 +40,12 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
     public function create(ItemComment $comment): ItemComment
     {
-        $document = $comment->toArray();
+        $this->getIndexManager()->ensureIndexExists();
+
         $params = [
             'index' => $this->getIndexName(),
             'id' => $comment->getId(),
-            'body' => $document,
+            'body' => $comment->toArray(),
             'refresh' => true,
         ];
 
@@ -54,6 +59,8 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
     public function findByItemUri(string $itemUri): array
     {
+        $this->getIndexManager()->ensureIndexExists();
+
         $params = [
             'index' => $this->getIndexName(),
             'body' => [
@@ -63,7 +70,7 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
                 ],
                 'query' => [
                     'term' => [
-                        'itemUri.keyword' => $itemUri,
+                        'itemUri' => $itemUri,
                     ],
                 ],
             ],
@@ -71,14 +78,12 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
         try {
             $response = $this->getClient()->search($params)->asArray();
-        } catch (\Throwable $exception) {
-            // Fallback for indices where itemUri is already keyword-mapped.
-            $params['body']['query'] = [
-                'term' => [
-                    'itemUri' => $itemUri,
-                ],
-            ];
-            $response = $this->getClient()->search($params)->asArray();
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Failed to search item comments in Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
         }
 
         $comments = [];
@@ -100,12 +105,14 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
     public function countByItemUri(string $itemUri): int
     {
+        $this->getIndexManager()->ensureIndexExists();
+
         $params = [
             'index' => $this->getIndexName(),
             'body' => [
                 'query' => [
                     'term' => [
-                        'itemUri.keyword' => $itemUri,
+                        'itemUri' => $itemUri,
                     ],
                 ],
             ],
@@ -113,13 +120,12 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
         try {
             $response = $this->getClient()->count($params)->asArray();
-        } catch (\Throwable $exception) {
-            $params['body']['query'] = [
-                'term' => [
-                    'itemUri' => $itemUri,
-                ],
-            ];
-            $response = $this->getClient()->count($params)->asArray();
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Failed to count item comments in Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
         }
 
         return (int) ($response['count'] ?? 0);
@@ -132,11 +138,54 @@ class ElasticsearchItemCommentAdapter extends ConfigurableService implements Ite
 
     private function getClient(): Client
     {
-        return $this->getServiceLocator()->get(Client::class);
+        $locator = $this->getServiceLocator();
+        if ($locator->has(Client::class)) {
+            return $locator->get(Client::class);
+        }
+
+        if (method_exists($locator, 'getContainer')) {
+            try {
+                return $locator->getContainer()->get(Client::class);
+            } catch (Throwable $exception) {
+                // Fall through to ServiceOptions factory.
+            }
+        }
+
+        $serviceOptions = $locator->get(ServiceOptions::SERVICE_ID);
+
+        return (new ElasticSearchClientFactory(new ElasticSearchConfig($serviceOptions)))->create();
     }
 
     private function getIndexPrefixer(): IndexPrefixer
     {
-        return $this->getServiceLocator()->get(IndexPrefixer::class);
+        $locator = $this->getServiceLocator();
+        if ($locator->has(IndexPrefixer::class)) {
+            return $locator->get(IndexPrefixer::class);
+        }
+
+        if (method_exists($locator, 'getContainer')) {
+            try {
+                return $locator->getContainer()->get(IndexPrefixer::class);
+            } catch (Throwable $exception) {
+                // Fall through to ServiceOptions factory.
+            }
+        }
+
+        $serviceOptions = $locator->get(ServiceOptions::SERVICE_ID);
+
+        return new IndexPrefixer(new ElasticSearchConfig($serviceOptions));
+    }
+
+    private function getIndexManager(): ItemCommentIndexManager
+    {
+        $locator = $this->getServiceLocator();
+        if ($locator->has(ItemCommentIndexManager::SERVICE_ID)) {
+            return $locator->get(ItemCommentIndexManager::SERVICE_ID);
+        }
+
+        $manager = new ItemCommentIndexManager();
+        $manager->setServiceLocator($locator);
+
+        return $manager;
     }
 }

--- a/model/Comment/ItemCommentIndexManager.php
+++ b/model/Comment/ItemCommentIndexManager.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\model\Comment;
+
+use Elastic\Elasticsearch\Client;
+use oat\generis\model\DependencyInjection\ServiceOptions;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchClientFactory;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchConfig;
+use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Creates / ensures the dedicated item-comments Elasticsearch index.
+ */
+class ItemCommentIndexManager extends ConfigurableService
+{
+    public const SERVICE_ID = 'taoAdvancedSearch/ItemCommentIndexManager';
+
+    public function ensureIndexExists(): string
+    {
+        $indexName = $this->getIndexName();
+        $client = $this->getClient();
+
+        try {
+            $exists = $client->indices()->exists(['index' => $indexName])->asBool();
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Unable to check item-comments index existence: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+
+        if ($exists) {
+            return $indexName;
+        }
+
+        $definition = $this->getIndexDefinition();
+        $definition['index'] = $indexName;
+
+        try {
+            $client->indices()->create($definition);
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Unable to create item-comments index "%s": %s', $indexName, $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+
+        return $indexName;
+    }
+
+    public function getIndexName(): string
+    {
+        return $this->getIndexPrefixer()->prefix(ElasticsearchItemCommentAdapter::INDEX_NAME);
+    }
+
+    /**
+     * @return array{index: string, body: array}
+     */
+    public function getIndexDefinition(): array
+    {
+        $file = dirname(__DIR__, 2) . '/config/item-comments.conf.php';
+        if (!is_readable($file)) {
+            throw new RuntimeException(sprintf('Item comments index config not readable: %s', $file));
+        }
+
+        /** @var array{index: string, body: array} $definition */
+        $definition = require $file;
+
+        return $definition;
+    }
+
+    private function getClient(): Client
+    {
+        $locator = $this->getServiceLocator();
+        if ($locator->has(Client::class)) {
+            return $locator->get(Client::class);
+        }
+
+        if (method_exists($locator, 'getContainer')) {
+            try {
+                return $locator->getContainer()->get(Client::class);
+            } catch (Throwable $exception) {
+                // Fall through to ServiceOptions factory.
+            }
+        }
+
+        $serviceOptions = $locator->get(ServiceOptions::SERVICE_ID);
+
+        return (new ElasticSearchClientFactory(new ElasticSearchConfig($serviceOptions)))->create();
+    }
+
+    private function getIndexPrefixer(): IndexPrefixer
+    {
+        $locator = $this->getServiceLocator();
+        if ($locator->has(IndexPrefixer::class)) {
+            return $locator->get(IndexPrefixer::class);
+        }
+
+        if (method_exists($locator, 'getContainer')) {
+            try {
+                return $locator->getContainer()->get(IndexPrefixer::class);
+            } catch (Throwable $exception) {
+                // Fall through to ServiceOptions factory.
+            }
+        }
+
+        $serviceOptions = $locator->get(ServiceOptions::SERVICE_ID);
+
+        return new IndexPrefixer(new ElasticSearchConfig($serviceOptions));
+    }
+}

--- a/model/SearchEngine/ServiceProvider/SearchEngineProvider.php
+++ b/model/SearchEngine/ServiceProvider/SearchEngineProvider.php
@@ -30,6 +30,8 @@ use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\DependencyInjection\ServiceOptions;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\session\SessionService;
+use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchClientFactory;
 use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearchConfig;
@@ -159,6 +161,12 @@ class SearchEngineProvider implements ContainerServiceProviderInterface
             )->public();
 
         $services->set(SearchResultNormalizer::class, SearchResultNormalizer::class)
+            ->public();
+
+        $services->set(ItemCommentIndexManager::class, ItemCommentIndexManager::class)
+            ->public();
+
+        $services->set(ElasticsearchItemCommentAdapter::class, ElasticsearchItemCommentAdapter::class)
             ->public();
     }
 }

--- a/scripts/install/RegisterItemCommentElasticsearchAdapter.php
+++ b/scripts/install/RegisterItemCommentElasticsearchAdapter.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+
+/**
+ * Replaces taoItems RDF comment persistence with Elasticsearch when AS is installed.
+ */
+class RegisterItemCommentElasticsearchAdapter extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        $serviceManager = $this->getServiceManager();
+
+        $adapter = new ElasticsearchItemCommentAdapter();
+        $serviceManager->propagate($adapter);
+        $serviceManager->register(ElasticsearchItemCommentAdapter::SERVICE_ID, $adapter);
+
+        if (!$serviceManager->has(ItemCommentPersistenceProxy::SERVICE_ID)) {
+            return;
+        }
+
+        /** @var ItemCommentPersistenceProxy $proxy */
+        $proxy = $serviceManager->get(ItemCommentPersistenceProxy::SERVICE_ID);
+        $proxy->setOption(
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER,
+            ElasticsearchItemCommentAdapter::SERVICE_ID
+        );
+        $serviceManager->register(ItemCommentPersistenceProxy::SERVICE_ID, $proxy);
+    }
+}

--- a/scripts/install/RegisterItemCommentElasticsearchAdapter.php
+++ b/scripts/install/RegisterItemCommentElasticsearchAdapter.php
@@ -23,11 +23,13 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\scripts\install;
 
 use oat\oatbox\extension\InstallAction;
+use oat\oatbox\reporting\Report;
 use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
 use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
 
 /**
- * Replaces taoItems RDF comment persistence with Elasticsearch when AS is installed.
+ * Creates item-comments ES index and replaces taoItems RDF comment persistence with Elasticsearch.
  */
 class RegisterItemCommentElasticsearchAdapter extends InstallAction
 {
@@ -35,20 +37,28 @@ class RegisterItemCommentElasticsearchAdapter extends InstallAction
     {
         $serviceManager = $this->getServiceManager();
 
+        $indexManager = new ItemCommentIndexManager();
+        $serviceManager->propagate($indexManager);
+        $serviceManager->register(ItemCommentIndexManager::SERVICE_ID, $indexManager);
+
         $adapter = new ElasticsearchItemCommentAdapter();
         $serviceManager->propagate($adapter);
         $serviceManager->register(ElasticsearchItemCommentAdapter::SERVICE_ID, $adapter);
 
-        if (!$serviceManager->has(ItemCommentPersistenceProxy::SERVICE_ID)) {
-            return;
+        $indexName = $indexManager->ensureIndexExists();
+
+        if ($serviceManager->has(ItemCommentPersistenceProxy::SERVICE_ID)) {
+            /** @var ItemCommentPersistenceProxy $proxy */
+            $proxy = $serviceManager->get(ItemCommentPersistenceProxy::SERVICE_ID);
+            $proxy->setOption(
+                ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER,
+                ElasticsearchItemCommentAdapter::SERVICE_ID
+            );
+            $serviceManager->register(ItemCommentPersistenceProxy::SERVICE_ID, $proxy);
         }
 
-        /** @var ItemCommentPersistenceProxy $proxy */
-        $proxy = $serviceManager->get(ItemCommentPersistenceProxy::SERVICE_ID);
-        $proxy->setOption(
-            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER,
-            ElasticsearchItemCommentAdapter::SERVICE_ID
+        return Report::createSuccess(
+            sprintf('Item comments persistence uses Elasticsearch index "%s"', $indexName)
         );
-        $serviceManager->register(ItemCommentPersistenceProxy::SERVICE_ID, $proxy);
     }
 }

--- a/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
+++ b/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\tests\Unit\Comment;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
+use oat\taoItems\model\Comment\ItemComment;
+use DG\BypassFinals;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ElasticsearchItemCommentAdapterTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var Client|MockObject */
+    private $client;
+
+    /** @var IndexPrefixer|MockObject */
+    private $prefixer;
+
+    private ElasticsearchItemCommentAdapter $sut;
+
+    protected function setUp(): void
+    {
+        BypassFinals::enable();
+        $this->client = $this->createMock(Client::class);
+        $this->prefixer = $this->createMock(IndexPrefixer::class);
+        $this->prefixer->method('prefix')->willReturnCallback(
+            static function (string $name): string {
+                return 'test-' . $name;
+            }
+        );
+
+        $this->sut = new ElasticsearchItemCommentAdapter();
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                Client::class => $this->client,
+                IndexPrefixer::class => $this->prefixer,
+            ])
+        );
+    }
+
+    public function testCreateIndexesDocument(): void
+    {
+        $comment = new ItemComment(
+            'c1',
+            'item-1',
+            'author',
+            'Author',
+            'hello',
+            '2026-08-03T10:00:00+00:00'
+        );
+
+        $response = $this->createMock(Elasticsearch::class);
+        $response->method('asArray')->willReturn(['result' => 'created']);
+
+        $this->client
+            ->expects($this->once())
+            ->method('index')
+            ->with($this->callback(static function (array $params): bool {
+                return $params['index'] === 'test-item-comments'
+                    && $params['id'] === 'c1'
+                    && $params['body']['body'] === 'hello';
+            }))
+            ->willReturn($response);
+
+        $this->assertSame($comment, $this->sut->create($comment));
+    }
+
+    public function testFindByItemUriMapsHits(): void
+    {
+        $response = $this->createMock(Elasticsearch::class);
+        $response->method('asArray')->willReturn([
+            'hits' => [
+                'hits' => [
+                    [
+                        '_id' => 'c1',
+                        '_source' => [
+                            'id' => 'c1',
+                            'itemUri' => 'item-1',
+                            'authorId' => 'author',
+                            'authorLabel' => 'Author',
+                            'body' => 'hello',
+                            'createdAt' => '2026-08-03T10:00:00+00:00',
+                            'status' => 'active',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->client
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn($response);
+
+        $comments = $this->sut->findByItemUri('item-1');
+        $this->assertCount(1, $comments);
+        $this->assertSame('hello', $comments[0]->getBody());
+    }
+}

--- a/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
+++ b/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
@@ -26,6 +26,7 @@ use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use oat\generis\test\ServiceManagerMockTrait;
 use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
 use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use oat\taoItems\model\Comment\ItemComment;
 use DG\BypassFinals;
@@ -42,6 +43,9 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
     /** @var IndexPrefixer|MockObject */
     private $prefixer;
 
+    /** @var ItemCommentIndexManager|MockObject */
+    private $indexManager;
+
     private ElasticsearchItemCommentAdapter $sut;
 
     protected function setUp(): void
@@ -54,12 +58,15 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
                 return 'test-' . $name;
             }
         );
+        $this->indexManager = $this->createMock(ItemCommentIndexManager::class);
+        $this->indexManager->method('ensureIndexExists')->willReturn('test-item-comments');
 
         $this->sut = new ElasticsearchItemCommentAdapter();
         $this->sut->setServiceLocator(
             $this->getServiceManagerMock([
                 Client::class => $this->client,
                 IndexPrefixer::class => $this->prefixer,
+                ItemCommentIndexManager::SERVICE_ID => $this->indexManager,
             ])
         );
     }
@@ -78,6 +85,7 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
         $response = $this->createMock(Elasticsearch::class);
         $response->method('asArray')->willReturn(['result' => 'created']);
 
+        $this->indexManager->expects($this->once())->method('ensureIndexExists');
         $this->client
             ->expects($this->once())
             ->method('index')
@@ -116,6 +124,9 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
         $this->client
             ->expects($this->once())
             ->method('search')
+            ->with($this->callback(static function (array $params): bool {
+                return ($params['body']['query']['term']['itemUri'] ?? null) === 'item-1';
+            }))
             ->willReturn($response);
 
         $comments = $this->sut->findByItemUri('item-1');

--- a/tests/Unit/Comment/ItemCommentIndexManagerTest.php
+++ b/tests/Unit/Comment/ItemCommentIndexManagerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\tests\Unit\Comment;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Endpoints\Indices;
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
+use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
+use DG\BypassFinals;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ItemCommentIndexManagerTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var Client|MockObject */
+    private $client;
+
+    /** @var Indices|MockObject */
+    private $indices;
+
+    private ItemCommentIndexManager $sut;
+
+    protected function setUp(): void
+    {
+        BypassFinals::enable();
+
+        $this->indices = $this->createMock(Indices::class);
+        $this->client = $this->createMock(Client::class);
+        $this->client->method('indices')->willReturn($this->indices);
+
+        $prefixer = $this->createMock(IndexPrefixer::class);
+        $prefixer->method('prefix')->willReturn('test-item-comments');
+
+        $this->sut = new ItemCommentIndexManager();
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                Client::class => $this->client,
+                IndexPrefixer::class => $prefixer,
+            ])
+        );
+    }
+
+    public function testEnsureIndexExistsReturnsWhenAlreadyPresent(): void
+    {
+        $existsResponse = $this->createMock(Elasticsearch::class);
+        $existsResponse->method('asBool')->willReturn(true);
+
+        $this->indices->expects($this->once())->method('exists')->willReturn($existsResponse);
+        $this->indices->expects($this->never())->method('create');
+
+        $this->assertSame('test-item-comments', $this->sut->ensureIndexExists());
+    }
+
+    public function testEnsureIndexExistsCreatesMissingIndex(): void
+    {
+        $existsResponse = $this->createMock(Elasticsearch::class);
+        $existsResponse->method('asBool')->willReturn(false);
+
+        $this->indices->expects($this->once())->method('exists')->willReturn($existsResponse);
+        $this->indices
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->callback(static function (array $definition): bool {
+                return $definition['index'] === 'test-item-comments'
+                    && isset($definition['body']['mappings']['properties']['itemUri'])
+                    && $definition['body']['mappings']['properties']['itemUri']['type'] === 'keyword'
+                    && $definition['body']['mappings']['properties']['createdAt']['type'] === 'date';
+            }));
+
+        $this->assertSame('test-item-comments', $this->sut->ensureIndexExists());
+    }
+}

--- a/tests/Unit/Comment/RegisterItemCommentElasticsearchAdapterTest.php
+++ b/tests/Unit/Comment/RegisterItemCommentElasticsearchAdapterTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoAdvancedSearch\tests\Unit\Comment;
+
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\oatbox\service\ServiceManager;
+use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\scripts\install\RegisterItemCommentElasticsearchAdapter;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use PHPUnit\Framework\TestCase;
+
+class RegisterItemCommentElasticsearchAdapterTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    public function testReplacesActiveAdapterOnProxy(): void
+    {
+        $proxy = new ItemCommentPersistenceProxy([
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => RdfItemCommentAdapter::SERVICE_ID,
+        ]);
+
+        $services = [];
+        $serviceManager = $this->createMock(ServiceManager::class);
+        $serviceManager->method('propagate')->willReturnArgument(0);
+        $serviceManager
+            ->method('has')
+            ->willReturnCallback(static function (string $id) use (&$services): bool {
+                return isset($services[$id]);
+            });
+        $serviceManager
+            ->method('get')
+            ->willReturnCallback(static function (string $id) use (&$services) {
+                return $services[$id];
+            });
+        $serviceManager
+            ->method('register')
+            ->willReturnCallback(static function (string $id, $service) use (&$services): void {
+                $services[$id] = $service;
+            });
+
+        $services[ItemCommentPersistenceProxy::SERVICE_ID] = $proxy;
+
+        $script = new RegisterItemCommentElasticsearchAdapter();
+        $script->setServiceLocator($serviceManager);
+        $script([]);
+
+        $this->assertArrayHasKey(ElasticsearchItemCommentAdapter::SERVICE_ID, $services);
+        $this->assertSame(
+            ElasticsearchItemCommentAdapter::SERVICE_ID,
+            $services[ItemCommentPersistenceProxy::SERVICE_ID]->getOption(
+                ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER
+            )
+        );
+    }
+}

--- a/tests/Unit/Comment/RegisterItemCommentElasticsearchAdapterTest.php
+++ b/tests/Unit/Comment/RegisterItemCommentElasticsearchAdapterTest.php
@@ -22,27 +22,48 @@ declare(strict_types=1);
 
 namespace oat\taoAdvancedSearch\tests\Unit\Comment;
 
-use oat\generis\test\ServiceManagerMockTrait;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Endpoints\Indices;
+use Elastic\Elasticsearch\Response\Elasticsearch;
 use oat\oatbox\service\ServiceManager;
 use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
+use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
+use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use oat\taoAdvancedSearch\scripts\install\RegisterItemCommentElasticsearchAdapter;
 use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
 use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use DG\BypassFinals;
 use PHPUnit\Framework\TestCase;
 
 class RegisterItemCommentElasticsearchAdapterTest extends TestCase
 {
-    use ServiceManagerMockTrait;
-
-    public function testReplacesActiveAdapterOnProxy(): void
+    public function testReplacesActiveAdapterOnProxyAndEnsuresIndex(): void
     {
+        BypassFinals::enable();
+
         $proxy = new ItemCommentPersistenceProxy([
             ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => RdfItemCommentAdapter::SERVICE_ID,
         ]);
 
-        $services = [];
+        $existsResponse = $this->createMock(Elasticsearch::class);
+        $existsResponse->method('asBool')->willReturn(true);
+
+        $indices = $this->createMock(Indices::class);
+        $indices->expects($this->once())->method('exists')->willReturn($existsResponse);
+
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $prefixer = $this->createMock(IndexPrefixer::class);
+        $prefixer->method('prefix')->willReturn('test-item-comments');
+
+        $services = [
+            Client::class => $client,
+            IndexPrefixer::class => $prefixer,
+            ItemCommentPersistenceProxy::SERVICE_ID => $proxy,
+        ];
+
         $serviceManager = $this->createMock(ServiceManager::class);
-        $serviceManager->method('propagate')->willReturnArgument(0);
         $serviceManager
             ->method('has')
             ->willReturnCallback(static function (string $id) use (&$services): bool {
@@ -55,16 +76,27 @@ class RegisterItemCommentElasticsearchAdapterTest extends TestCase
             });
         $serviceManager
             ->method('register')
-            ->willReturnCallback(static function (string $id, $service) use (&$services): void {
+            ->willReturnCallback(static function (string $id, $service) use (&$services, $serviceManager): void {
+                if (method_exists($service, 'setServiceLocator')) {
+                    $service->setServiceLocator($serviceManager);
+                }
                 $services[$id] = $service;
             });
-
-        $services[ItemCommentPersistenceProxy::SERVICE_ID] = $proxy;
+        $serviceManager
+            ->method('propagate')
+            ->willReturnCallback(static function ($service) use ($serviceManager) {
+                if (method_exists($service, 'setServiceLocator')) {
+                    $service->setServiceLocator($serviceManager);
+                }
+                return $service;
+            });
 
         $script = new RegisterItemCommentElasticsearchAdapter();
         $script->setServiceLocator($serviceManager);
-        $script([]);
+        $report = $script([]);
 
+        $this->assertNotNull($report);
+        $this->assertArrayHasKey(ItemCommentIndexManager::SERVICE_ID, $services);
         $this->assertArrayHasKey(ElasticsearchItemCommentAdapter::SERVICE_ID, $services);
         $this->assertSame(
             ElasticsearchItemCommentAdapter::SERVICE_ID,


### PR DESCRIPTION
## Summary
- Add Elasticsearch item comment adapter
- On install, replace `taoItems` comment persistence proxy active adapter with ES
- Depend on `oat-sa/extension-tao-item` for persistence interface

## Test plan
- [ ] Install/migrate AS switches proxy to Elasticsearch adapter
- [ ] Unit tests under `tests/Unit/Comment/`
- [ ] With FF enabled, comments create/list/count use ES

Related: NYSED-19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item comments are now stored and searched through Elasticsearch.
  * Comment searches support retrieval by item, result counting, and consistent chronological ordering.
  * The required comment index is created and configured automatically during installation and upgrades.

* **Bug Fixes**
  * Improved reliability of comment persistence and retrieval through indexed search.

* **Tests**
  * Added coverage for indexing, searching, index setup, and storage adapter activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->