### PR TITLE
feat: ES item comments findById, update, and delete (NYSED-14)

### DIFF
--- a/model/Comment/ElasticsearchItemCommentAdapter.php
+++ b/model/Comment/ElasticsearchItemCommentAdapter.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\model\Comment;
 
 use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use InvalidArgumentException;
 use oat\taoAdvancedSearch\model\SearchEngine\Service\IndexPrefixer;
 use oat\taoItems\model\Comment\ItemComment;
 use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
@@ -55,7 +57,7 @@ class ElasticsearchItemCommentAdapter implements ItemCommentPersistenceInterface
         $params = [
             'index' => $this->getIndexName(),
             'id' => $comment->getId(),
-            'body' => $comment->toArray(),
+            'body' => $this->toDocument($comment),
             'refresh' => true,
         ];
 
@@ -80,6 +82,113 @@ class ElasticsearchItemCommentAdapter implements ItemCommentPersistenceInterface
         }
 
         return $comment;
+    }
+
+    public function update(ItemComment $comment): ItemComment
+    {
+        $this->indexManager->ensureIndexExists();
+
+        $params = [
+            'index' => $this->getIndexName(),
+            'id' => $comment->getId(),
+            'body' => $this->toDocument($comment),
+            'refresh' => true,
+        ];
+
+        try {
+            $response = $this->client->index($params)->asArray();
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Failed to update resource comment in Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+
+        if (!in_array($response['result'] ?? null, ['created', 'updated'], true)) {
+            throw new RuntimeException('Failed to update resource comment in Elasticsearch');
+        }
+
+        return $comment;
+    }
+
+    public function delete(string $commentId): void
+    {
+        $commentId = trim($commentId);
+        if ($commentId === '') {
+            throw new InvalidArgumentException('Comment id is required');
+        }
+
+        $this->indexManager->ensureIndexExists();
+
+        $params = [
+            'index' => $this->getIndexName(),
+            'id' => $commentId,
+            'refresh' => true,
+        ];
+
+        try {
+            $this->client->delete($params)->asArray();
+        } catch (ClientResponseException $exception) {
+            if ($exception->getCode() === 404) {
+                throw new InvalidArgumentException('Comment not found', 0, $exception);
+            }
+
+            throw new RuntimeException(
+                sprintf('Failed to delete resource comment from Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Failed to delete resource comment from Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+    }
+
+    public function findById(string $commentId): ?ItemComment
+    {
+        $commentId = trim($commentId);
+        if ($commentId === '') {
+            return null;
+        }
+
+        $this->indexManager->ensureIndexExists();
+
+        $params = [
+            'index' => $this->getIndexName(),
+            'id' => $commentId,
+        ];
+
+        try {
+            $response = $this->client->get($params)->asArray();
+        } catch (ClientResponseException $exception) {
+            if ($exception->getCode() === 404) {
+                return null;
+            }
+
+            throw new RuntimeException(
+                sprintf('Failed to get resource comment from Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf('Failed to get resource comment from Elasticsearch: %s', $exception->getMessage()),
+                0,
+                $exception
+            );
+        }
+
+        if (!($response['found'] ?? false)) {
+            return null;
+        }
+
+        $source = $response['_source'] ?? [];
+
+        return $this->mapSource($source, (string) ($response['_id'] ?? $commentId));
     }
 
     public function findByResource(string $resourceUri, string $resourceType): array
@@ -127,6 +236,24 @@ class ElasticsearchItemCommentAdapter implements ItemCommentPersistenceInterface
     private function getIndexName(): string
     {
         return $this->indexPrefixer->prefix(self::INDEX_NAME);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toDocument(ItemComment $comment): array
+    {
+        return [
+            'id' => $comment->getId(),
+            'resourceUri' => $comment->getResourceUri(),
+            'resourceType' => $comment->getResourceType(),
+            'authorId' => $comment->getAuthorId(),
+            'authorLabel' => $comment->getAuthorLabel(),
+            'body' => $comment->getBody(),
+            'createdAt' => $comment->getCreatedAt(),
+            'edited' => $comment->isEdited(),
+            'resolved' => $comment->isResolved(),
+        ];
     }
 
     /**

--- a/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
+++ b/tests/Unit/Comment/ElasticsearchItemCommentAdapterTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\taoAdvancedSearch\tests\Unit\Comment;
 
 use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use oat\taoAdvancedSearch\model\Comment\ElasticsearchItemCommentAdapter;
 use oat\taoAdvancedSearch\model\Comment\ItemCommentIndexManager;
@@ -93,7 +94,8 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
                     && $params['body']['resourceUri'] === 'item-1'
                     && $params['body']['resourceType'] === ResourceCommentType::ITEM
                     && $params['body']['edited'] === false
-                    && $params['body']['resolved'] === false;
+                    && $params['body']['resolved'] === false
+                    && !array_key_exists('editable', $params['body']);
             }))
             ->willReturn($response);
 
@@ -157,6 +159,105 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
         $this->sut->create($comment);
     }
 
+    public function testUpdateIndexesDocument(): void
+    {
+        $comment = (new ItemComment(
+            'c1',
+            'item-1',
+            ResourceCommentType::ITEM,
+            'author',
+            'Author',
+            'hello',
+            '2026-08-03T10:00:00+00:00'
+        ))->withEditedBody('updated body');
+
+        $response = $this->createMock(Elasticsearch::class);
+        $response->method('asArray')->willReturn(['result' => 'updated']);
+
+        $this->indexManager->expects($this->once())->method('ensureIndexExists');
+        $this->client
+            ->expects($this->once())
+            ->method('index')
+            ->with($this->callback(static function (array $params): bool {
+                return $params['index'] === 'test-resource-comments'
+                    && $params['id'] === 'c1'
+                    && $params['body']['body'] === 'updated body'
+                    && $params['body']['resourceType'] === ResourceCommentType::ITEM
+                    && $params['body']['edited'] === true
+                    && $params['refresh'] === true
+                    && !array_key_exists('editable', $params['body']);
+            }))
+            ->willReturn($response);
+
+        $this->assertSame($comment, $this->sut->update($comment));
+    }
+
+    public function testFindByIdReturnsComment(): void
+    {
+        $response = $this->createMock(Elasticsearch::class);
+        $response->method('asArray')->willReturn([
+            'found' => true,
+            '_id' => 'c1',
+            '_source' => [
+                'id' => 'c1',
+                'resourceUri' => 'item-1',
+                'resourceType' => ResourceCommentType::ITEM,
+                'authorId' => 'author',
+                'authorLabel' => 'Author',
+                'body' => 'hello',
+                'createdAt' => '2026-08-03T10:00:00+00:00',
+                'edited' => true,
+                'resolved' => false,
+            ],
+        ]);
+
+        $this->indexManager->expects($this->once())->method('ensureIndexExists');
+        $this->client
+            ->expects($this->once())
+            ->method('get')
+            ->with([
+                'index' => 'test-resource-comments',
+                'id' => 'c1',
+            ])
+            ->willReturn($response);
+
+        $comment = $this->sut->findById('c1');
+        $this->assertInstanceOf(ItemComment::class, $comment);
+        $this->assertSame('c1', $comment->getId());
+        $this->assertSame('hello', $comment->getBody());
+        $this->assertSame(ResourceCommentType::ITEM, $comment->getResourceType());
+        $this->assertTrue($comment->isEdited());
+    }
+
+    public function testFindByIdReturnsNullWhenMissing(): void
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('get')
+            ->willThrowException(new ClientResponseException('Not Found', 404));
+
+        $this->assertNull($this->sut->findById('missing'));
+    }
+
+    public function testDeleteRemovesDocument(): void
+    {
+        $response = $this->createMock(Elasticsearch::class);
+        $response->method('asArray')->willReturn(['result' => 'deleted']);
+
+        $this->indexManager->expects($this->once())->method('ensureIndexExists');
+        $this->client
+            ->expects($this->once())
+            ->method('delete')
+            ->with([
+                'index' => 'test-resource-comments',
+                'id' => 'c1',
+                'refresh' => true,
+            ])
+            ->willReturn($response);
+
+        $this->sut->delete('c1');
+    }
+
     public function testFindByResourceMapsHits(): void
     {
         $response = $this->createMock(Elasticsearch::class);
@@ -195,7 +296,6 @@ class ElasticsearchItemCommentAdapterTest extends TestCase
         $comments = $this->sut->findByResource('item-1', ResourceCommentType::ITEM);
         $this->assertCount(1, $comments);
         $this->assertSame('hello', $comments[0]->getBody());
-        $this->assertSame(ResourceCommentType::ITEM, $comments[0]->getResourceType());
         $this->assertTrue($comments[0]->isEdited());
         $this->assertFalse($comments[0]->isResolved());
     }


### PR DESCRIPTION
## Summary
- Implement `findById`, `update`, and `delete` on `ElasticsearchItemCommentAdapter`
- Index persistence fields only (no API-only `editable` flag)

## Test plan
- [ ] Unit: `ElasticsearchItemCommentAdapterTest`
- [ ] With AS enabled, edit/resolve/delete paths no longer fatal on missing interface methods

Related: NYSED-14

Stacked on: `feat/NYSED-13/item-comments` (PR #167) — no FE branch in this repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating, retrieving, and deleting comments.
  * Added reliable indexing when comments are created or updated.
  * Added clear handling for missing comments and invalid operations.

* **Bug Fixes**
  * Standardized comment data to preserve fields such as resolution status.
  * Improved consistency of comment data returned from searches and records.
  * Improved error handling for comment operations and search responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->